### PR TITLE
add Learning Resources page with gradient hero section

### DIFF
--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -1,3 +1,5 @@
+import Navbar from "../components/navbar";
+
 export default function PublicLayout({
   children,
 }: {
@@ -5,6 +7,7 @@ export default function PublicLayout({
 }) {
   return (
     <div className="min-h-screen flex flex-col">
+      <Navbar />
       <main className="flex-1 flex flex-col" id="main-content">
         {children}
       </main>

--- a/app/(public)/resources/page.tsx
+++ b/app/(public)/resources/page.tsx
@@ -1,0 +1,42 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Learning Resources | SkillSync",
+  description: "Explore curated learning resources to boost your skills.",
+};
+
+export default function LearningResourcesPage() {
+  return (
+    <div className="min-h-screen">
+      {/* Hero Section */}
+      <section className="bg-gradient-to-br from-purple-700 via-purple-600 to-violet-500 py-20 px-6">
+        <div className="max-w-4xl mx-auto text-center">
+          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight">
+            Learning Resources
+          </h1>
+          <p className="text-lg sm:text-xl text-purple-100 max-w-2xl mx-auto leading-relaxed">
+            Explore curated guides, tutorials, and tools handpicked to help you
+            grow your skills, land opportunities, and connect with the right mentors.
+          </p>
+        </div>
+      </section>
+
+      {/* Placeholder Content */}
+      <div className="max-w-7xl mx-auto px-6 py-16">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-gray-200 p-6 bg-white shadow-sm"
+            >
+              <div className="h-6 w-3/4 bg-gray-200 rounded animate-pulse mb-3" />
+              <div className="h-4 w-full bg-gray-100 rounded animate-pulse mb-2" />
+              <div className="h-4 w-5/6 bg-gray-100 rounded animate-pulse mb-2" />
+              <div className="h-4 w-2/3 bg-gray-100 rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect } from "react";
 
 const NAV_LINKS = [


### PR DESCRIPTION
Description:
  Creates the /resources route under the public section with a purple gradient hero and placeholder resource cards. Wires the global  
  navbar into the public layout so it renders across all public pages.
  
Closes #112 
Closes #113