### PR TITLE
feat: create reusable LearningTrackCard component

### DIFF
--- a/app/components/learning-track/LearningTrackCard.css
+++ b/app/components/learning-track/LearningTrackCard.css
@@ -1,0 +1,102 @@
+.track-card {
+  background: #111827;
+  border-radius: 16px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.track-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+}
+
+/* Image Section */
+.track-image-wrapper {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9; /* Proper image ratio */
+  overflow: hidden;
+}
+
+.track-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Category Tag */
+.track-category {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  background: #10b981;
+  color: white;
+  padding: 6px 12px;
+  font-size: 12px;
+  border-radius: 20px;
+  font-weight: 500;
+}
+
+/* Content */
+.track-content {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.track-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: #ffffff;
+}
+
+.track-description {
+  font-size: 14px;
+  color: #9ca3af;
+  margin-bottom: 16px;
+  flex-grow: 1;
+}
+
+.track-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  color: #d1d5db;
+  margin-bottom: 16px;
+}
+
+/* Button */
+.track-button {
+  background: linear-gradient(135deg, #10b981, #059669);
+  border: none;
+  padding: 12px;
+  border-radius: 10px;
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.track-button:hover {
+  transform: scale(1.02);
+}
+
+.track-button:active {
+  transform: scale(0.98);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .track-title {
+    font-size: 16px;
+  }
+
+  .track-description {
+    font-size: 13px;
+  }
+}

--- a/app/components/learning-track/LearningTrackCard.jsx
+++ b/app/components/learning-track/LearningTrackCard.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import "./LearningTrackCard.css";
+
+const LearningTrackCard = ({
+  image,
+  category,
+  title,
+  description,
+  lessonCount,
+  duration,
+  onStart,
+}) => {
+  return (
+    <div className="track-card">
+      <div className="track-image-wrapper">
+        <img src={image} alt={title} className="track-image" />
+        <span className="track-category">{category}</span>
+      </div>
+
+      <div className="track-content">
+        <h3 className="track-title">{title}</h3>
+        <p className="track-description">{description}</p>
+
+        <div className="track-meta">
+          <span>{lessonCount} Lessons</span>
+          <span>{duration}</span>
+        </div>
+
+        <button className="track-button" onClick={onStart}>
+          Start Learning
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default LearningTrackCard;


### PR DESCRIPTION
Closes #118

---

- Build reusable LearningTrackCard component
- Add image with fixed 16:9 aspect ratio
- Include category tag, title, description, lesson count and duration
- Add styled "Start Learning" button with hover effects
- Ensure responsive layout
- Add modular CSS styling



closeds #118 