### PR TITLE
feat(ui): create reusable CategoryBadge component with dynamic color …

### DIFF
--- a/app/components/ui/ CategoryBadge.tsx
+++ b/app/components/ui/ CategoryBadge.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+interface CategoryBadgeProps {
+  category: string;
+  className?: string;
+}
+
+const categoryColorMap: Record<string, string> = {
+  blockchain: "bg-emerald-100 text-emerald-800",
+  health: "bg-blue-100 text-blue-800",
+  finance: "bg-yellow-100 text-yellow-800",
+  ai: "bg-purple-100 text-purple-800",
+  default: "bg-gray-100 text-gray-800",
+};
+
+const CategoryBadge: React.FC<CategoryBadgeProps> = ({
+  category,
+  className = "",
+}) => {
+  const normalized = category.toLowerCase();
+  const colorClass =
+    categoryColorMap[normalized] || categoryColorMap.default;
+
+  return (
+    <span
+      className={`inline-block px-2 py-1 text-xs font-medium rounded-full ${colorClass} ${className}`}
+    >
+      {category}
+    </span>
+  );
+};
+
+export default CategoryBadge;

--- a/app/components/ui/ categoryBadge.types.ts
+++ b/app/components/ui/ categoryBadge.types.ts
@@ -1,0 +1,5 @@
+export interface CategoryBadgeProps {
+  label: string;
+  color?: string;      // Hex, rgb, or css color
+  className?: string;  // Allow extension styling
+}


### PR DESCRIPTION
## Summary
Created a reusable CategoryBadge component for learning track cards.

## Features
- Dynamic color mapping per category
- Small rounded pill design
- Accepts category prop
- Extendable via className
- Default fallback styling

## Usage
<CategoryBadge category="Blockchain" />

Reusable across the entire platform.



closes #119 