### PR TITLE
fix(frontend): improve responsive grid breakpoints on resources page

### DIFF
--- a/app/components/Featuredlearningtracks.tsx
+++ b/app/components/Featuredlearningtracks.tsx
@@ -131,7 +131,7 @@ export function FeaturedLearningTracks({
       </div>
 
       {/* Cards grid — stacks on mobile, 3-col on md+ */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
         {visible.map((track) => (
           <LearningTrackCard key={track.id} track={track} />
         ))}

--- a/app/components/PlatformStatistics.tsx
+++ b/app/components/PlatformStatistics.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import { motion } from 'framer-motion';
 

--- a/app/components/quick-access.tsx
+++ b/app/components/quick-access.tsx
@@ -39,7 +39,7 @@ export default function QuickAccess() {
           Quick Access
         </h2>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 md:gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
           {resources.map((resource) => (
             <article
               key={resource.title}


### PR DESCRIPTION
- Add "use client" to PlatformStatistics to fix Framer Motion server error
- Quick Access grid: xl:grid-cols-4 → lg:grid-cols-4 (4 → 2 → 1)
- Learning Tracks grid: remove sm:grid-cols-2 for clean 3 → 1 collapse

issue: #125
