### PR TITLE
featured mentor and mentor discovery section components created

### DIFF
--- a/components/FeaturedMentorSection
+++ b/components/FeaturedMentorSection
@@ -1,0 +1,428 @@
+'use client';
+
+import Link from 'next/link';
+
+const featuredMentor = {
+  name: 'Dr. Amara Osei',
+  title: 'Senior AI Engineer & Tech Lead',
+  company: 'Google DeepMind',
+  image: '/images/featured-mentor.jpg',
+  badge: 'Mentor of the Month',
+  rating: 4.97,
+  sessions: 312,
+  students: 148,
+  tags: ['Machine Learning', 'Python', 'Career Growth'],
+  bio: `Amara brings 12+ years building production AI systems at Google, Meta, and two YC-backed startups. She specializes in helping engineers break into ML roles, navigate senior promotions, and build impactful side projects that actually ship.`,
+  quote: `"I don't just review your resume — I help you think like the engineer companies are desperate to hire."`,
+};
+
+export default function FeaturedMentorSection() {
+  return (
+    <section className="featured-mentor-section">
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;1,400&family=DM+Sans:wght@300;400;500;600&display=swap');
+
+        .featured-mentor-section {
+          font-family: 'DM Sans', sans-serif;
+          background: #0a0a0f;
+          padding: 96px 24px;
+          position: relative;
+          overflow: hidden;
+        }
+
+        .featured-mentor-section::before {
+          content: '';
+          position: absolute;
+          top: -120px;
+          left: -120px;
+          width: 480px;
+          height: 480px;
+          background: radial-gradient(circle, rgba(234, 179, 8, 0.12) 0%, transparent 70%);
+          pointer-events: none;
+        }
+
+        .featured-mentor-section::after {
+          content: '';
+          position: absolute;
+          bottom: -80px;
+          right: -80px;
+          width: 360px;
+          height: 360px;
+          background: radial-gradient(circle, rgba(168, 85, 247, 0.1) 0%, transparent 70%);
+          pointer-events: none;
+        }
+
+        .section-label {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          background: rgba(234, 179, 8, 0.1);
+          border: 1px solid rgba(234, 179, 8, 0.25);
+          color: #eab308;
+          font-size: 11px;
+          font-weight: 600;
+          letter-spacing: 0.12em;
+          text-transform: uppercase;
+          padding: 6px 14px;
+          border-radius: 100px;
+          margin-bottom: 20px;
+        }
+
+        .section-label span {
+          width: 6px;
+          height: 6px;
+          background: #eab308;
+          border-radius: 50%;
+          display: inline-block;
+          animation: pulse 2s ease-in-out infinite;
+        }
+
+        @keyframes pulse {
+          0%, 100% { opacity: 1; transform: scale(1); }
+          50% { opacity: 0.5; transform: scale(0.8); }
+        }
+
+        .section-heading {
+          font-family: 'Playfair Display', serif;
+          font-size: clamp(28px, 4vw, 44px);
+          font-weight: 700;
+          color: #f5f0e8;
+          line-height: 1.2;
+          margin-bottom: 56px;
+          max-width: 420px;
+        }
+
+        .section-heading em {
+          font-style: italic;
+          color: #eab308;
+        }
+
+        .mentor-card {
+          max-width: 1100px;
+          margin: 0 auto;
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: 0;
+          background: #13131a;
+          border-radius: 24px;
+          border: 1px solid rgba(255,255,255,0.07);
+          overflow: hidden;
+          box-shadow: 0 32px 80px rgba(0,0,0,0.5);
+          position: relative;
+          z-index: 1;
+        }
+
+        @media (max-width: 768px) {
+          .mentor-card {
+            grid-template-columns: 1fr;
+          }
+        }
+
+        /* LEFT: Image panel */
+        .mentor-image-panel {
+          position: relative;
+          min-height: 480px;
+          background: #1a1a24;
+        }
+
+        .mentor-image-panel img {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+          display: block;
+          filter: saturate(0.85);
+        }
+
+        /* Fallback avatar */
+        .mentor-avatar-fallback {
+          width: 100%;
+          height: 100%;
+          min-height: 480px;
+          background: linear-gradient(145deg, #1e1e2e 0%, #2a1f3d 50%, #1a2040 100%);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: 'Playfair Display', serif;
+          font-size: 96px;
+          color: rgba(234,179,8,0.3);
+          letter-spacing: -2px;
+        }
+
+        .mentor-image-overlay {
+          position: absolute;
+          inset: 0;
+          background: linear-gradient(
+            to right,
+            transparent 50%,
+            #13131a 100%
+          ), linear-gradient(
+            to top,
+            rgba(0,0,0,0.6) 0%,
+            transparent 50%
+          );
+        }
+
+        @media (max-width: 768px) {
+          .mentor-image-overlay {
+            background: linear-gradient(to bottom, transparent 50%, #13131a 100%);
+          }
+        }
+
+        .mentor-badge {
+          position: absolute;
+          top: 20px;
+          left: 20px;
+          background: rgba(234, 179, 8, 0.15);
+          backdrop-filter: blur(12px);
+          border: 1px solid rgba(234,179,8,0.4);
+          color: #eab308;
+          font-size: 11px;
+          font-weight: 600;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          padding: 6px 12px;
+          border-radius: 8px;
+          display: flex;
+          align-items: center;
+          gap: 6px;
+        }
+
+        .mentor-badge svg {
+          width: 12px;
+          height: 12px;
+          fill: #eab308;
+        }
+
+        /* RIGHT: Content panel */
+        .mentor-content-panel {
+          padding: 48px 44px;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+        }
+
+        @media (max-width: 768px) {
+          .mentor-content-panel {
+            padding: 36px 28px;
+          }
+        }
+
+        .mentor-name {
+          font-family: 'Playfair Display', serif;
+          font-size: clamp(26px, 3vw, 38px);
+          font-weight: 700;
+          color: #f5f0e8;
+          margin: 0 0 6px;
+          line-height: 1.15;
+        }
+
+        .mentor-title {
+          font-size: 14px;
+          color: rgba(245,240,232,0.5);
+          font-weight: 400;
+          margin: 0 0 4px;
+        }
+
+        .mentor-company {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          color: #eab308;
+          font-size: 13px;
+          font-weight: 500;
+          margin-bottom: 28px;
+        }
+
+        .mentor-stats {
+          display: flex;
+          gap: 24px;
+          margin-bottom: 28px;
+          padding-bottom: 28px;
+          border-bottom: 1px solid rgba(255,255,255,0.07);
+        }
+
+        .stat {
+          display: flex;
+          flex-direction: column;
+          gap: 2px;
+        }
+
+        .stat-value {
+          font-family: 'Playfair Display', serif;
+          font-size: 22px;
+          font-weight: 700;
+          color: #f5f0e8;
+        }
+
+        .stat-label {
+          font-size: 11px;
+          color: rgba(245,240,232,0.4);
+          text-transform: uppercase;
+          letter-spacing: 0.08em;
+        }
+
+        .mentor-quote {
+          font-family: 'Playfair Display', serif;
+          font-style: italic;
+          font-size: 15px;
+          line-height: 1.7;
+          color: rgba(245,240,232,0.65);
+          margin-bottom: 20px;
+          padding-left: 16px;
+          border-left: 2px solid rgba(234,179,8,0.5);
+        }
+
+        .mentor-bio {
+          font-size: 14px;
+          line-height: 1.75;
+          color: rgba(245,240,232,0.55);
+          margin-bottom: 28px;
+        }
+
+        .mentor-tags {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+          margin-bottom: 32px;
+        }
+
+        .mentor-tag {
+          background: rgba(255,255,255,0.05);
+          border: 1px solid rgba(255,255,255,0.1);
+          color: rgba(245,240,232,0.65);
+          font-size: 12px;
+          padding: 5px 12px;
+          border-radius: 100px;
+          font-weight: 500;
+        }
+
+        .mentor-cta {
+          display: inline-flex;
+          align-items: center;
+          gap: 10px;
+          background: #eab308;
+          color: #0a0a0f;
+          font-size: 14px;
+          font-weight: 600;
+          padding: 14px 28px;
+          border-radius: 12px;
+          text-decoration: none;
+          transition: all 0.2s ease;
+          align-self: flex-start;
+          letter-spacing: 0.01em;
+        }
+
+        .mentor-cta:hover {
+          background: #f5c842;
+          transform: translateY(-2px);
+          box-shadow: 0 12px 32px rgba(234,179,8,0.25);
+        }
+
+        .mentor-cta svg {
+          width: 16px;
+          height: 16px;
+          transition: transform 0.2s ease;
+        }
+
+        .mentor-cta:hover svg {
+          transform: translateX(3px);
+        }
+
+        .secondary-cta {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          color: rgba(245,240,232,0.5);
+          font-size: 13px;
+          text-decoration: none;
+          margin-left: 20px;
+          transition: color 0.2s;
+        }
+
+        .secondary-cta:hover {
+          color: rgba(245,240,232,0.85);
+        }
+
+        .cta-row {
+          display: flex;
+          align-items: center;
+        }
+      `}</style>
+
+      <div style={{ maxWidth: '1100px', margin: '0 auto', textAlign: 'center', marginBottom: '16px' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <div className="section-label">
+            <span></span>
+            Featured This Week
+          </div>
+          <h2 className="section-heading">
+            Learn from someone who's <em>been there.</em>
+          </h2>
+        </div>
+      </div>
+
+      <div className="mentor-card">
+        {/* Left: Image */}
+        <div className="mentor-image-panel">
+          <div className="mentor-avatar-fallback">AO</div>
+          <div className="mentor-image-overlay" />
+          <div className="mentor-badge">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+            </svg>
+            {featuredMentor.badge}
+          </div>
+        </div>
+
+        {/* Right: Content */}
+        <div className="mentor-content-panel">
+          <h3 className="mentor-name">{featuredMentor.name}</h3>
+          <p className="mentor-title">{featuredMentor.title}</p>
+          <div className="mentor-company">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+              <polyline points="9 22 9 12 15 12 15 22"/>
+            </svg>
+            {featuredMentor.company}
+          </div>
+
+          <div className="mentor-stats">
+            <div className="stat">
+              <span className="stat-value">★ {featuredMentor.rating}</span>
+              <span className="stat-label">Rating</span>
+            </div>
+            <div className="stat">
+              <span className="stat-value">{featuredMentor.sessions}+</span>
+              <span className="stat-label">Sessions</span>
+            </div>
+            <div className="stat">
+              <span className="stat-value">{featuredMentor.students}</span>
+              <span className="stat-label">Mentees</span>
+            </div>
+          </div>
+
+          <blockquote className="mentor-quote">{featuredMentor.quote}</blockquote>
+          <p className="mentor-bio">{featuredMentor.bio}</p>
+
+          <div className="mentor-tags">
+            {featuredMentor.tags.map(tag => (
+              <span key={tag} className="mentor-tag">{tag}</span>
+            ))}
+          </div>
+
+          <div className="cta-row">
+            <Link href="/mentors/amara-osei" className="mentor-cta">
+              Book a Session
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                <path d="M5 12h14M12 5l7 7-7 7"/>
+              </svg>
+            </Link>
+            <Link href="/mentors/amara-osei" className="secondary-cta">
+              View full profile →
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/MentorDiscoverySection.tsx
+++ b/components/MentorDiscoverySection.tsx
@@ -1,0 +1,529 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+
+const filters = ['All', 'Engineering', 'Design', 'Product', 'Business', 'Data'];
+
+const mentors = [
+  {
+    id: 1,
+    name: 'Kwame Asante',
+    role: 'Staff Engineer',
+    company: 'Stripe',
+    category: 'Engineering',
+    initials: 'KA',
+    accent: '#3b82f6',
+    bg: '#0f1f3d',
+    available: true,
+    rating: 4.95,
+    sessions: 204,
+    description: 'Helps engineers level up to Staff and beyond. Specialises in distributed systems, technical leadership, and promo packets.',
+    tags: ['System Design', 'Leadership', 'Go'],
+  },
+  {
+    id: 2,
+    name: 'Priya Menon',
+    role: 'Head of Product Design',
+    company: 'Figma',
+    category: 'Design',
+    initials: 'PM',
+    accent: '#a855f7',
+    bg: '#1e0f3d',
+    available: true,
+    rating: 4.98,
+    sessions: 187,
+    description: 'Portfolio reviews, design system strategy, and breaking into senior IC or management tracks at top-tier product companies.',
+    tags: ['Figma', 'Design Systems', 'Portfolio'],
+  },
+  {
+    id: 3,
+    name: 'Tomás Reyes',
+    role: 'Senior PM',
+    company: 'Notion',
+    category: 'Product',
+    initials: 'TR',
+    accent: '#10b981',
+    bg: '#0a2318',
+    available: false,
+    rating: 4.91,
+    sessions: 139,
+    description: 'From APM to PM to Group PM — Tomás has made every jump and guides others through the same transitions with precision.',
+    tags: ['Roadmapping', 'Stakeholders', 'APM'],
+  },
+  {
+    id: 4,
+    name: 'Aisha Nwosu',
+    role: 'Data Science Lead',
+    company: 'Spotify',
+    category: 'Data',
+    initials: 'AN',
+    accent: '#f59e0b',
+    bg: '#2a1800',
+    available: true,
+    rating: 4.93,
+    sessions: 256,
+    description: 'ML pipelines, A/B testing at scale, and transitioning from academia to industry. Obsessed with making data teams actually functional.',
+    tags: ['Python', 'ML', 'Analytics'],
+  },
+  {
+    id: 5,
+    name: 'Leon Fischer',
+    role: 'Founding Engineer',
+    company: '3× YC Startups',
+    category: 'Engineering',
+    initials: 'LF',
+    accent: '#ef4444',
+    bg: '#2a0a0a',
+    available: true,
+    rating: 4.89,
+    sessions: 98,
+    description: 'Zero to one builder. Helps early-career devs ship fast, make technical decisions under uncertainty, and navigate startup chaos.',
+    tags: ['React', 'Node', 'Startup'],
+  },
+  {
+    id: 6,
+    name: 'Sara Lindqvist',
+    role: 'VP of Growth',
+    company: 'Duolingo',
+    category: 'Business',
+    initials: 'SL',
+    accent: '#06b6d4',
+    bg: '#011f26',
+    available: false,
+    rating: 4.96,
+    sessions: 321,
+    description: 'Growth loops, retention mechanics, and go-to-market for consumer apps. Former founder. Brutally practical and candid.',
+    tags: ['Growth', 'GTM', 'Retention'],
+  },
+];
+
+export default function MentorDiscoverySection() {
+  const [activeFilter, setActiveFilter] = useState('All');
+
+  const filtered = activeFilter === 'All'
+    ? mentors
+    : mentors.filter(m => m.category === activeFilter);
+
+  return (
+    <section className="mentor-discovery">
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=Syne:wght@600;700;800&family=DM+Sans:wght@300;400;500&display=swap');
+
+        .mentor-discovery {
+          font-family: 'DM Sans', sans-serif;
+          background: #f7f5f2;
+          padding: 88px 24px;
+          position: relative;
+        }
+
+        .md-inner {
+          max-width: 1160px;
+          margin: 0 auto;
+        }
+
+        /* Header */
+        .md-header {
+          display: flex;
+          align-items: flex-end;
+          justify-content: space-between;
+          gap: 24px;
+          margin-bottom: 40px;
+          flex-wrap: wrap;
+        }
+
+        .md-eyebrow {
+          font-family: 'DM Sans', sans-serif;
+          font-size: 11px;
+          font-weight: 500;
+          letter-spacing: 0.15em;
+          text-transform: uppercase;
+          color: #94928d;
+          margin-bottom: 10px;
+        }
+
+        .md-title {
+          font-family: 'Syne', sans-serif;
+          font-size: clamp(28px, 4vw, 46px);
+          font-weight: 800;
+          color: #141210;
+          line-height: 1.1;
+          margin: 0;
+        }
+
+        .md-title span {
+          position: relative;
+          display: inline-block;
+        }
+
+        .md-title span::after {
+          content: '';
+          position: absolute;
+          bottom: 2px;
+          left: 0;
+          width: 100%;
+          height: 3px;
+          background: #141210;
+          border-radius: 2px;
+        }
+
+        .md-view-all {
+          font-size: 13px;
+          font-weight: 500;
+          color: #141210;
+          text-decoration: none;
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          white-space: nowrap;
+          padding-bottom: 2px;
+          border-bottom: 1px solid rgba(20,18,16,0.25);
+          transition: border-color 0.2s;
+        }
+
+        .md-view-all:hover {
+          border-color: #141210;
+        }
+
+        /* Filters */
+        .md-filters {
+          display: flex;
+          gap: 8px;
+          flex-wrap: wrap;
+          margin-bottom: 40px;
+        }
+
+        .md-filter-btn {
+          background: none;
+          border: 1.5px solid rgba(20,18,16,0.15);
+          color: #6b6860;
+          font-family: 'DM Sans', sans-serif;
+          font-size: 13px;
+          font-weight: 500;
+          padding: 8px 18px;
+          border-radius: 100px;
+          cursor: pointer;
+          transition: all 0.18s ease;
+        }
+
+        .md-filter-btn:hover {
+          border-color: rgba(20,18,16,0.4);
+          color: #141210;
+        }
+
+        .md-filter-btn.active {
+          background: #141210;
+          border-color: #141210;
+          color: #f7f5f2;
+        }
+
+        /* Grid */
+        .md-grid {
+          display: grid;
+          grid-template-columns: repeat(3, 1fr);
+          gap: 20px;
+        }
+
+        @media (max-width: 1024px) {
+          .md-grid { grid-template-columns: repeat(2, 1fr); }
+        }
+
+        @media (max-width: 600px) {
+          .md-grid { grid-template-columns: 1fr; }
+          .md-header { align-items: flex-start; flex-direction: column; gap: 12px; }
+        }
+
+        /* Card */
+        .md-card {
+          background: #fff;
+          border-radius: 20px;
+          overflow: hidden;
+          border: 1px solid rgba(20,18,16,0.07);
+          transition: transform 0.22s ease, box-shadow 0.22s ease;
+          display: flex;
+          flex-direction: column;
+        }
+
+        .md-card:hover {
+          transform: translateY(-4px);
+          box-shadow: 0 20px 48px rgba(20,18,16,0.1);
+        }
+
+        .md-card-top {
+          padding: 28px 28px 20px;
+          display: flex;
+          align-items: flex-start;
+          gap: 16px;
+        }
+
+        /* Avatar */
+        .md-avatar {
+          width: 56px;
+          height: 56px;
+          border-radius: 14px;
+          flex-shrink: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: 'Syne', sans-serif;
+          font-size: 18px;
+          font-weight: 700;
+          letter-spacing: -0.5px;
+          position: relative;
+        }
+
+        .md-avatar img {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+          border-radius: 14px;
+        }
+
+        .md-availability {
+          position: absolute;
+          bottom: -2px;
+          right: -2px;
+          width: 12px;
+          height: 12px;
+          border-radius: 50%;
+          border: 2px solid #fff;
+        }
+
+        .md-availability.available { background: #10b981; }
+        .md-availability.busy { background: #d1d5db; }
+
+        /* Meta */
+        .md-meta {
+          flex: 1;
+          min-width: 0;
+        }
+
+        .md-name {
+          font-family: 'Syne', sans-serif;
+          font-size: 17px;
+          font-weight: 700;
+          color: #141210;
+          margin: 0 0 2px;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+
+        .md-role {
+          font-size: 13px;
+          color: #94928d;
+          margin: 0;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+
+        .md-company {
+          font-size: 12px;
+          font-weight: 500;
+          margin-top: 2px;
+        }
+
+        /* Rating pill */
+        .md-rating {
+          display: inline-flex;
+          align-items: center;
+          gap: 4px;
+          background: #f7f5f2;
+          border-radius: 8px;
+          padding: 4px 9px;
+          font-size: 12px;
+          font-weight: 600;
+          color: #141210;
+          flex-shrink: 0;
+        }
+
+        .md-rating-star {
+          color: #f59e0b;
+          font-size: 11px;
+        }
+
+        /* Divider */
+        .md-divider {
+          height: 1px;
+          background: rgba(20,18,16,0.07);
+          margin: 0 28px;
+        }
+
+        /* Body */
+        .md-card-body {
+          padding: 20px 28px;
+          flex: 1;
+          display: flex;
+          flex-direction: column;
+          gap: 16px;
+        }
+
+        .md-description {
+          font-size: 13.5px;
+          line-height: 1.7;
+          color: #6b6860;
+          margin: 0;
+          flex: 1;
+        }
+
+        .md-tags {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 6px;
+        }
+
+        .md-tag {
+          font-size: 11.5px;
+          font-weight: 500;
+          padding: 4px 10px;
+          border-radius: 6px;
+          background: #f7f5f2;
+          color: #6b6860;
+          border: 1px solid rgba(20,18,16,0.08);
+        }
+
+        /* Footer */
+        .md-card-footer {
+          padding: 16px 28px 24px;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+        }
+
+        .md-sessions {
+          font-size: 12px;
+          color: #94928d;
+        }
+
+        .md-sessions strong {
+          color: #141210;
+          font-weight: 600;
+        }
+
+        .md-book-btn {
+          font-family: 'DM Sans', sans-serif;
+          font-size: 12.5px;
+          font-weight: 600;
+          padding: 9px 18px;
+          border-radius: 10px;
+          text-decoration: none;
+          transition: all 0.18s ease;
+          border: none;
+          cursor: pointer;
+        }
+
+        .md-book-btn.available {
+          background: #141210;
+          color: #f7f5f2;
+        }
+
+        .md-book-btn.available:hover {
+          background: #2d2a27;
+        }
+
+        .md-book-btn.busy {
+          background: #f0efed;
+          color: #94928d;
+          cursor: default;
+        }
+
+        /* Empty state */
+        .md-empty {
+          grid-column: 1 / -1;
+          text-align: center;
+          padding: 64px 24px;
+          color: #94928d;
+          font-size: 15px;
+        }
+      `}</style>
+
+      <div className="md-inner">
+        {/* Header */}
+        <div className="md-header">
+          <div>
+            <p className="md-eyebrow">Our Community</p>
+            <h2 className="md-title">
+              Find your <span>mentor</span>
+            </h2>
+          </div>
+          <Link href="/mentors" className="md-view-all">
+            Browse all mentors →
+          </Link>
+        </div>
+
+        {/* Filters */}
+        <div className="md-filters">
+          {filters.map(f => (
+            <button
+              key={f}
+              className={`md-filter-btn${activeFilter === f ? ' active' : ''}`}
+              onClick={() => setActiveFilter(f)}
+            >
+              {f}
+            </button>
+          ))}
+        </div>
+
+        {/* Grid */}
+        <div className="md-grid">
+          {filtered.length === 0 && (
+            <div className="md-empty">No mentors found in this category yet.</div>
+          )}
+
+          {filtered.map(mentor => (
+            <div key={mentor.id} className="md-card">
+              {/* Top */}
+              <div className="md-card-top">
+                <div
+                  className="md-avatar"
+                  style={{ background: mentor.bg, color: mentor.accent }}
+                >
+                  {mentor.initials}
+                  <span className={`md-availability ${mentor.available ? 'available' : 'busy'}`} />
+                </div>
+
+                <div className="md-meta">
+                  <p className="md-name">{mentor.name}</p>
+                  <p className="md-role">{mentor.role}</p>
+                  <p className="md-company" style={{ color: mentor.accent }}>{mentor.company}</p>
+                </div>
+
+                <div className="md-rating">
+                  <span className="md-rating-star">★</span>
+                  {mentor.rating}
+                </div>
+              </div>
+
+              <div className="md-divider" />
+
+              {/* Body */}
+              <div className="md-card-body">
+                <p className="md-description">{mentor.description}</p>
+                <div className="md-tags">
+                  {mentor.tags.map(tag => (
+                    <span key={tag} className="md-tag">{tag}</span>
+                  ))}
+                </div>
+              </div>
+
+              {/* Footer */}
+              <div className="md-card-footer">
+                <span className="md-sessions">
+                  <strong>{mentor.sessions}</strong> sessions
+                </span>
+                <Link
+                  href={mentor.available ? `/mentors/${mentor.id}` : '#'}
+                  className={`md-book-btn ${mentor.available ? 'available' : 'busy'}`}
+                >
+                  {mentor.available ? 'Book session' : 'Fully booked'}
+                </Link>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,6 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
     "**/*.mts"
-  ],
+, "components/FeaturedMentorSection"  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
closes #156 

closes #154 

Here's what's packed in MentorDiscoverySection component:
Layout & Grid

3-column grid → 2-column on tablet → 1-column on mobile, all via CSS grid with no extra libraries

Card anatomy (top to bottom):

Coloured initials avatar with a per-mentor accent colour — replace with an <img> tag when real photos are available
Green/grey availability dot with a white ring border
Name, role, and company (company inherits the accent colour)
Star rating pill in the top-right corner
Description paragraph and skill tags
Session count + "Book session" / "Fully booked" CTA at the footer

Filter bar — client-side category filters (All, Engineering, Design, Product, Business, Data) driven by useState, matching the category field on each mentor object
To wire up real data — swap the mentors array for props or an API fetch; the shape is straightforward (name, role, company, category, description, tags, rating, sessions, available, optional image).


FeaturedMentorSection component. A few notes on what's built in:
Design approach — Dark editorial aesthetic with amber/gold accents to create a premium "spotlight" feel that clearly differentiates the featured mentor from a standard card.
Structure:

Left panel — profile image with graceful fallback initials avatar, floating badge, and a darkroom-style gradient overlay
Right panel — name, role, company, stat row (rating / sessions / mentees), pull quote, bio, skill tags, and the CTA row

