### PR TITLE
Support for username

### DIFF
--- a/app/(public)/profiles/[username]/page.tsx
+++ b/app/(public)/profiles/[username]/page.tsx
@@ -1,0 +1,66 @@
+import { notFound } from 'next/navigation';
+import { UserService } from '@/services/user.service';
+import Link from 'next/link';
+
+const userService = new UserService();
+
+interface ProfilePageProps {
+  params: Promise<{
+    username: string;
+  }>;
+}
+
+export async function generateMetadata({ params }: ProfilePageProps) {
+  const { username } = await params;
+  const user = await userService.getUserByUsername(username);
+
+  if (!user) {
+    return { title: 'User not found | SkillSync' };
+  }
+
+  const displayName = user.displayName || user.email?.split('@')[0] || 'User';
+
+  return {
+    title: `${displayName} | SkillSync`,
+    description: `Profile of ${displayName} on SkillSync`,
+  };
+}
+
+export default async function ProfilePage({ params }: ProfilePageProps) {
+  const { username } = await params;
+  const user = await userService.getUserByUsername(username);
+
+  if (!user) {
+    notFound();
+  }
+
+  const displayName = user.displayName || user.email?.split('@')[0] || 'User';
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <div className="bg-white shadow rounded-lg p-6">
+        <div className="flex items-center space-x-4">
+          <div className="flex-shrink-0">
+            <div className="h-20 w-20 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center text-white text-2xl font-bold">
+              {(displayName.charAt(0) || 'U').toUpperCase()}
+            </div>
+          </div>
+          <div className="flex-1">
+            <h1 className="text-2xl font-bold text-gray-900">{displayName}</h1>
+            {user.username && (
+              <p className="text-gray-500">@{user.username}</p>
+            )}
+            <p className="text-gray-500">{user.email}</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <h2 className="text-lg font-medium text-gray-900">About</h2>
+          <p className="mt-2 text-gray-600">
+            This is {displayName}&#39;s public profile on SkillSync.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/api/user/username/available/route.ts
+++ b/app/api/user/username/available/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { validateUsername } from '@/lib/username-validation';
+import { UserService } from '@/services/user.service';
+
+const userService = new UserService();
+
+export const GET = async (req: NextRequest): Promise<NextResponse> => {
+  try {
+    const searchParams = req.nextUrl.searchParams;
+    const username = searchParams.get('username');
+
+    if (!username) {
+      return NextResponse.json(
+        { error: 'Username query parameter is required' },
+        { status: 400 }
+      );
+    }
+
+    // Validate format first
+    const validation = validateUsername(username);
+    if (!validation.valid) {
+      return NextResponse.json(
+        { available: false, reason: validation.error },
+        { status: 200 }
+      );
+    }
+
+    const availability = await userService.checkUsernameAvailability(username);
+    return NextResponse.json(
+      { available: availability.available, reason: availability.reason },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error('Username availability check error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+};

--- a/app/api/user/username/route.ts
+++ b/app/api/user/username/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { AuthUtils } from '@/lib/auth';
+import { UserService } from '@/services/user.service';
+
+const userService = new UserService();
+
+export const PATCH = async (req: NextRequest): Promise<NextResponse> => {
+  try {
+    const user = await AuthUtils.requireActiveUser(req);
+
+    const body = await req.json();
+    const { username } = body;
+
+    if (!username || typeof username !== 'string') {
+      return NextResponse.json(
+        { error: 'Username is required' },
+        { status: 400 }
+      );
+    }
+
+    // Get client info for audit log
+    const ipAddress = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || req.headers.get('x-real-ip') || undefined;
+    const userAgent = req.headers.get('user-agent') || undefined;
+
+    const result = await userService.changeUsername(user.id, username, ipAddress, userAgent);
+
+    if (!result.success) {
+      const status = result.error?.includes('cooldown') ? 403 : 400;
+      return NextResponse.json(
+        { error: result.error, remainingDays: result.remainingDays },
+        { status }
+      );
+    }
+
+    // Return updated user info
+    const updatedUser = result.user!;
+    return NextResponse.json({
+      user: {
+        id: updatedUser.id,
+        email: updatedUser.email,
+        fullName: updatedUser.fullName,
+        username: updatedUser.username,
+        displayName: updatedUser.displayName,
+        status: updatedUser.status,
+        isAdmin: updatedUser.isAdmin,
+        usernameChangedAt: updatedUser.usernameChangedAt,
+        updatedAt: updatedUser.updatedAt,
+      },
+    });
+  } catch (error) {
+    console.error('Username change error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+};

--- a/app/api/users/me/route.ts
+++ b/app/api/users/me/route.ts
@@ -5,14 +5,22 @@ export const GET = async (req: NextRequest): Promise<NextResponse> => {
   try {
     const user = await AuthUtils.requireActiveUser(req);
 
+    // Generate display name if not set (fallback for existing users)
+    const displayName =
+      user.displayName || user.email?.split('@')[0] || 'User';
+
     return NextResponse.json({
       user: {
         id: user.id,
         email: user.email,
         fullName: user.fullName,
+        username: user.username,
+        displayName,
         status: user.status,
         isAdmin: user.isAdmin,
         createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+        usernameChangedAt: user.usernameChangedAt,
       },
     });
   } catch (error) {

--- a/src/entities/AuditLog.entity.ts
+++ b/src/entities/AuditLog.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from './User.entity';
+
+@Entity('audit_logs')
+export class AuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'user_id' })
+  userId!: string;
+
+  @Column({ name: 'action' })
+  action!: string;
+
+  @Column({ name: 'old_value', nullable: true })
+  oldValue?: string;
+
+  @Column({ name: 'new_value', nullable: true })
+  newValue?: string;
+
+  @Column({ name: 'metadata', type: 'jsonb', nullable: true })
+  metadata?: Record<string, any>;
+
+  @Column({ name: 'ip_address', nullable: true })
+  ipAddress?: string;
+
+  @Column({ name: 'user_agent', nullable: true })
+  userAgent?: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user?: User;
+}

--- a/src/entities/User.entity.ts
+++ b/src/entities/User.entity.ts
@@ -33,6 +33,15 @@ export class User {
   @Column({ name: 'is_admin', default: false })
   isAdmin!: boolean;
 
+  @Column({ unique: true, nullable: true, length: 30 })
+  username?: string;
+
+  @Column({ name: 'display_name', nullable: true, length: 50 })
+  displayName?: string;
+
+  @Column({ name: 'username_changed_at', nullable: true })
+  usernameChangedAt?: Date;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
 
@@ -42,5 +51,15 @@ export class User {
   @BeforeInsert()
   setDefaults() {
     this.id = uuidv4();
+    if (!this.displayName) {
+      this.displayName = this.generateDefaultDisplayName();
+    }
+  }
+
+  private generateDefaultDisplayName(): string {
+    if (this.email) {
+      return this.email.split('@')[0];
+    }
+    return 'User';
   }
 }

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,5 +1,6 @@
 import { DataSource } from 'typeorm';
 import { User } from '@/entities/User.entity';
+import { AuditLog } from '@/entities/AuditLog.entity';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
@@ -17,7 +18,7 @@ export const AppDataSource = new DataSource({
   username: DB_USERNAME,
   password: DB_PASSWORD,
   database: DB_DATABASE,
-  entities: [User],
+  entities: [User, AuditLog],
   migrations: [__dirname + '/../migrations/*.ts'],
   synchronize: false, // Never use synchronize in production
   logging: process.env.NODE_ENV === 'development',

--- a/src/lib/username-validation.ts
+++ b/src/lib/username-validation.ts
@@ -1,0 +1,118 @@
+/**
+ * Username validation utility
+ * Rules:
+ * - Alphanumeric + underscore + dash only
+ * - Length: 3-30 characters
+ * - No consecutive special characters (__, --, _-, -_)
+ */
+
+export const USERNAME_MIN_LENGTH = 3;
+export const USERNAME_MAX_LENGTH = 30;
+export const USERNAME_COOLDOWN_DAYS = 30;
+
+/**
+ * Validates username format
+ * @param username - The username to validate
+ * @returns { valid: boolean, error?: string } validation result
+ */
+export function validateUsername(username: string): { valid: boolean; error?: string } {
+  if (!username || username.trim().length === 0) {
+    return { valid: false, error: 'Username is required' };
+  }
+
+  const trimmed = username.trim();
+
+  if (trimmed.length < USERNAME_MIN_LENGTH) {
+    return {
+      valid: false,
+      error: `Username must be at least ${USERNAME_MIN_LENGTH} characters`,
+    };
+  }
+
+  if (trimmed.length > USERNAME_MAX_LENGTH) {
+    return {
+      valid: false,
+      error: `Username must be no more than ${USERNAME_MAX_LENGTH} characters`,
+    };
+  }
+
+  // Only allow alphanumeric, underscore, and dash
+  const validPattern = /^[a-zA-Z0-9_-]+$/;
+  if (!validPattern.test(trimmed)) {
+    return {
+      valid: false,
+      error:
+        'Username can only contain letters, numbers, underscores, and dashes',
+    };
+  }
+
+  // No consecutive special characters
+  const consecutiveSpecial = /[_\-]{2,}|[_\-]{1,2}[_\-]{1,2}/;
+  if (consecutiveSpecial.test(trimmed)) {
+    return {
+      valid: false,
+      error: 'Username cannot contain consecutive special characters',
+    };
+  }
+
+  // Alternative simpler check: check for __, --, _-, -_
+  if (trimmed.includes('__') || trimmed.includes('--') || trimmed.includes('_-') || trimmed.includes('-_')) {
+    return {
+      valid: false,
+      error: 'Username cannot contain consecutive special characters',
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Checks if a username is available (not taken by another user)
+ * @param username - The username to check
+ * @param excludeUserId - Optional user ID to exclude (for username changes)
+ * @returns { available: boolean, reason?: string }
+ */
+export async function isUsernameAvailable(
+  username: string,
+  excludeUserId?: string
+): Promise<{ available: boolean; reason?: string }> {
+  // This function will be used by the API endpoint.
+  // The actual database query will be done in the route handler.
+  // This utility just provides the interface definition.
+  // We'll call the service from the route.
+  return { available: true };
+}
+
+/**
+ * Checks if a user can change their username based on cooldown
+ * @param lastChangedAt - Date of last username change (null if never changed)
+ * @returns { canChange: boolean; reason?: string; remainingDays?: number }
+ */
+export function canChangeUsername(
+  lastChangedAt: Date | null | undefined
+): {
+  canChange: boolean;
+  reason?: string;
+  remainingDays?: number;
+} {
+  if (!lastChangedAt) {
+    return { canChange: true };
+  }
+
+  const cooldownMs = USERNAME_COOLDOWN_DAYS * 24 * 60 * 60 * 1000;
+  const now = new Date();
+  const lastChange = new Date(lastChangedAt);
+  const msSinceChange = now.getTime() - lastChange.getTime();
+
+  if (msSinceChange < cooldownMs) {
+    const remainingMs = cooldownMs - msSinceChange;
+    const remainingDays = Math.ceil(remainingMs / (24 * 60 * 60 * 1000));
+    return {
+      canChange: false,
+      reason: `Username can only be changed once every ${USERNAME_COOLDOWN_DAYS} days`,
+      remainingDays,
+    };
+  }
+
+  return { canChange: true };
+}

--- a/src/migrations/1714260000000-AddUsernameAndDisplayNameToUsersTable.ts
+++ b/src/migrations/1714260000000-AddUsernameAndDisplayNameToUsersTable.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUsernameAndDisplayNameToUsersTable1714260000000 implements MigrationInterface {
+  name = 'AddUsernameAndDisplayNameToUsersTable1714260000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add username column (nullable initially for existing users)
+    await queryRunner.query(`
+      ALTER TABLE "users" ADD COLUMN "username" character varying(30);
+    `);
+
+    // Add display_name column
+    await queryRunner.query(`
+      ALTER TABLE "users" ADD COLUMN "display_name" character varying(50);
+    `);
+
+    // Add username_changed_at column to track cooldown
+    await queryRunner.query(`
+      ALTER TABLE "users" ADD COLUMN "username_changed_at" TIMESTAMP;
+    `);
+
+    // Create unique index on username (nulls allowed, non-null must be unique)
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_users_username" ON "users" ("username") WHERE "username" IS NOT NULL;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop the unique index
+    await queryRunner.query(`DROP INDEX "IDX_users_username"`);
+
+    // Drop the columns
+    await queryRunner.query(`
+      ALTER TABLE "users" DROP COLUMN "username";
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "users" DROP COLUMN "display_name";
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "users" DROP COLUMN "username_changed_at";
+    `);
+  }
+}

--- a/src/migrations/1714260000001-CreateAuditLogsTable.ts
+++ b/src/migrations/1714260000001-CreateAuditLogsTable.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAuditLogsTable1714260000001 implements MigrationInterface {
+  name = 'CreateAuditLogsTable1714260000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "audit_logs" (
+        "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+        "user_id" UUID NOT NULL,
+        "action" character varying NOT NULL,
+        "old_value" text,
+        "new_value" text,
+        "metadata" jsonb,
+        "ip_address" character varying,
+        "user_agent" character varying,
+        "created_at" TIMESTAMP NOT NULL DEFAULT NOW(),
+        CONSTRAINT "PK_audit_logs_id" PRIMARY KEY ("id")
+      );
+    `);
+
+    // Create index on user_id for faster lookups
+    await queryRunner.query(`
+      CREATE INDEX "IDX_audit_logs_user_id" ON "audit_logs" ("user_id");
+    `);
+
+    // Create index on action for filtering
+    await queryRunner.query(`
+      CREATE INDEX "IDX_audit_logs_action" ON "audit_logs" ("action");
+    `);
+
+    // Create index on created_at for time-based queries
+    await queryRunner.query(`
+      CREATE INDEX "IDX_audit_logs_created_at" ON "audit_logs" ("created_at");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_audit_logs_created_at"`);
+    await queryRunner.query(`DROP INDEX "IDX_audit_logs_action"`);
+    await queryRunner.query(`DROP INDEX "IDX_audit_logs_user_id"`);
+    await queryRunner.query(`DROP TABLE "audit_logs"`);
+  }
+}

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,0 +1,142 @@
+import { Repository } from 'typeorm';
+import { AppDataSource } from '@/lib/database';
+import { User } from '@/entities/User.entity';
+import { AuditLog } from '@/entities/AuditLog.entity';
+import { validateUsername, canChangeUsername } from '@/lib/username-validation';
+
+export class UserService {
+  private userRepository: Repository<User>;
+  private auditLogRepository: Repository<AuditLog>;
+
+  constructor(
+    userRepository?: Repository<User>,
+    auditLogRepository?: Repository<AuditLog>
+  ) {
+    this.userRepository = userRepository || AppDataSource.getRepository(User);
+    this.auditLogRepository = auditLogRepository || AppDataSource.getRepository(AuditLog);
+  }
+
+  /**
+   * Check if a username is available
+   * @param username - The username to check (case-insensitive)
+   * @param excludeUserId - Optional user ID to exclude (for username change)
+   * @returns Promise<{ available: boolean; reason?: string }>
+   */
+  async checkUsernameAvailability(username: string, excludeUserId?: string): Promise<{ available: boolean; reason?: string }> {
+    const normalizedUsername = username.trim().toLowerCase();
+    const existingUser = await this.userRepository.findOne({
+      where: { username: normalizedUsername },
+    });
+
+    if (existingUser && existingUser.id !== excludeUserId) {
+      return { available: false, reason: 'Username is already taken' };
+    }
+
+    return { available: true };
+  }
+
+  /**
+   * Change a user's username
+   * @param userId - ID of the user changing username
+   * @param newUsername - The desired new username
+   * @param ipAddress - Optional IP address for audit
+   * @param userAgent - Optional user agent for audit
+   * @returns Promise<{ success: boolean; user?: User; error?: string; remainingDays?: number }>
+   */
+  async changeUsername(
+    userId: string,
+    newUsername: string,
+    ipAddress?: string,
+    userAgent?: string
+  ): Promise<{
+    success: boolean;
+    user?: User;
+    error?: string;
+    remainingDays?: number;
+  }> {
+    // Validate username format
+    const validation = validateUsername(newUsername);
+    if (!validation.valid) {
+      return { success: false, error: validation.error };
+    }
+
+    const normalizedUsername = newUsername.trim().toLowerCase();
+
+    // Get the user
+    const user = await this.userRepository.findOne({
+      where: { id: userId },
+    });
+
+    if (!user) {
+      return { success: false, error: 'User not found' };
+    }
+
+    // Check if the new username is different from current (if set)
+    if (user.username === normalizedUsername) {
+      return { success: false, error: 'New username is the same as current username' };
+    }
+
+    // Check availability
+    const availability = await this.checkUsernameAvailability(normalizedUsername, userId);
+    if (!availability.available) {
+      return { success: false, error: availability.reason };
+    }
+
+    // Check cooldown
+    const cooldownCheck = canChangeUsername(user.usernameChangedAt);
+    if (!cooldownCheck.canChange) {
+      return {
+        success: false,
+        error: cooldownCheck.reason,
+        remainingDays: cooldownCheck.remainingDays,
+      };
+    }
+
+    const oldUsername = user.username;
+
+    // Perform update and audit in a transaction
+    await this.userRepository.manager.transaction(async (transactionalEntityManager) => {
+      const userRepo = transactionalEntityManager.getRepository(User);
+      const auditRepo = transactionalEntityManager.getRepository(AuditLog);
+
+      // Update user
+      await userRepo.update(
+        { id: userId },
+        { username: normalizedUsername, usernameChangedAt: new Date() }
+      );
+
+      // Create audit log
+      const auditLog = new AuditLog();
+      auditLog.userId = userId;
+      auditLog.action = 'username_change';
+      auditLog.oldValue = oldUsername;
+      auditLog.newValue = normalizedUsername;
+      auditLog.ipAddress = ipAddress;
+      auditLog.userAgent = userAgent;
+      await auditRepo.save(auditLog);
+    });
+
+    // Return updated user
+    const updatedUser = await this.userRepository.findOne({
+      where: { id: userId },
+    });
+
+    if (!updatedUser) {
+      // Should not happen after successful update, but handle defensively
+      return { success: false, error: 'Failed to retrieve updated user' };
+    }
+
+    return { success: true, user: updatedUser };
+  }
+
+  /**
+   * Get user by username
+   * @param username - The username to find
+   * @returns Promise<User | null>
+   */
+  async getUserByUsername(username: string): Promise<User | null> {
+    return await this.userRepository.findOne({
+      where: { username: username.toLowerCase() },
+    });
+  }
+}

--- a/tests/user-service.test.ts
+++ b/tests/user-service.test.ts
@@ -1,0 +1,195 @@
+import { UserService } from '@/services/user.service';
+import { Repository } from 'typeorm';
+import { User } from '@/entities/User.entity';
+import { AuditLog } from '@/entities/AuditLog.entity';
+
+// Helper to create mock repository
+function createMockRepository(): jest.Mocked<Repository<any>> {
+  return {
+    findOne: jest.fn(),
+    save: jest.fn(),
+    update: jest.fn(),
+    createQueryBuilder: jest.fn(() => ({
+      where: jest.fn().mockReturnThis(),
+      setParameters: jest.fn().mockReturnThis(),
+      getOne: jest.fn(),
+    })),
+    manager: {
+      transaction: jest.fn(),
+    } as any,
+  } as any;
+}
+
+describe('UserService', () => {
+  let mockUserRepo: jest.Mocked<Repository<any>>;
+  let mockAuditRepo: jest.Mocked<Repository<any>>;
+  let userService: UserService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUserRepo = createMockRepository();
+    mockAuditRepo = createMockRepository();
+
+    userService = new UserService(mockUserRepo as any, mockAuditRepo as any);
+  });
+
+  describe('checkUsernameAvailability', () => {
+    it('should return available if username does not exist', async () => {
+      mockUserRepo.findOne.mockResolvedValue(null);
+      const result = await userService.checkUsernameAvailability('newuser');
+      expect(result.available).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('should return not available if username exists', async () => {
+      const existingUser = { id: '123', username: 'taken' } as User;
+      mockUserRepo.findOne.mockResolvedValue(existingUser);
+      const result = await userService.checkUsernameAvailability('taken');
+      expect(result.available).toBe(false);
+      expect(result.reason).toBe('Username is already taken');
+    });
+
+    it('should ignore excluded userId', async () => {
+      const existingUser = { id: '123', username: 'myuser' } as User;
+      mockUserRepo.findOne.mockResolvedValue(existingUser);
+      const result = await userService.checkUsernameAvailability('myuser', '123');
+      expect(result.available).toBe(true);
+    });
+
+    it('should normalize username to lowercase', async () => {
+      mockUserRepo.findOne.mockResolvedValue(null);
+      await userService.checkUsernameAvailability('NewUser');
+      expect(mockUserRepo.findOne).toHaveBeenCalledWith({
+        where: { username: 'newuser' },
+      });
+    });
+  });
+
+  describe('changeUsername', () => {
+    const userId = 'user-123';
+    const oldUsername = 'olduser';
+    const baseUser = {
+      id: userId,
+      username: oldUsername,
+      email: 'test@example.com',
+      fullName: 'Test User',
+      password: 'hashed',
+      status: 'active',
+      isAdmin: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      usernameChangedAt: undefined,
+    } as any;
+
+    beforeEach(() => {
+      mockUserRepo.findOne.mockResolvedValue(baseUser);
+    });
+
+    it('should reject invalid username format', async () => {
+      const result = await userService.changeUsername(userId, 'ab');
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('at least 3 characters');
+    });
+
+    it('should reject if new username same as current', async () => {
+      const result = await userService.changeUsername(userId, 'olduser');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('New username is the same as current username');
+    });
+
+    it('should reject if username is taken by another user', async () => {
+      mockUserRepo.findOne
+        .mockResolvedValueOnce(baseUser) // initial user fetch
+        .mockResolvedValueOnce({ id: 'other', username: 'newuser' } as any); // availability check finds taken
+      const result = await userService.changeUsername(userId, 'newuser');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Username is already taken');
+    });
+
+    it('should reject if within cooldown period', async () => {
+      const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+      baseUser.usernameChangedAt = tenDaysAgo;
+
+      const result = await userService.changeUsername(userId, 'newuser');
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('30 days');
+      if (result.remainingDays) {
+        expect(result.remainingDays).toBeGreaterThan(19);
+        expect(result.remainingDays).toBeLessThanOrEqual(20);
+      }
+    });
+
+    it('should succeed and perform transaction correctly', async () => {
+      baseUser.usernameChangedAt = undefined;
+
+      const mockUpdate = jest.fn().mockResolvedValue({ affected: 1 });
+      const mockAuditSave = jest.fn().mockResolvedValue({});
+
+      const mockTransaction = jest.fn(async (callback) => {
+        const txManager = {
+          getRepository: jest.fn((entity) => {
+            if (entity === User) {
+              return { update: mockUpdate } as any;
+            }
+            if (entity === AuditLog) {
+              return { save: mockAuditSave } as any;
+            }
+            return {} as any;
+          }),
+        };
+        return await callback(txManager);
+      });
+
+      mockUserRepo.manager.transaction = mockTransaction;
+
+      const updatedUser = { ...baseUser, username: 'newuser_123', usernameChangedAt: new Date() } as any;
+      mockUserRepo.findOne
+        .mockResolvedValueOnce(baseUser) // initial fetch
+        .mockResolvedValueOnce(null)     // availability check (not taken)
+        .mockResolvedValueOnce(updatedUser); // final fetch
+
+      const result = await userService.changeUsername(userId, 'NewUser_123', '127.0.0.1', 'test-agent');
+
+      expect(result.success).toBe(true);
+      expect(result.user?.username).toBe('newuser_123');
+
+      expect(mockUserRepo.manager.transaction).toHaveBeenCalledTimes(1);
+      expect(mockUpdate).toHaveBeenCalledWith(
+        { id: userId },
+        expect.objectContaining({
+          username: 'newuser_123',
+          usernameChangedAt: expect.any(Date),
+        })
+      );
+      expect(mockAuditSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId,
+          action: 'username_change',
+          oldValue: oldUsername,
+          newValue: 'newuser_123',
+          ipAddress: '127.0.0.1',
+          userAgent: 'test-agent',
+        })
+      );
+    });
+  });
+
+  describe('getUserByUsername', () => {
+    it('should return user by username', async () => {
+      const user = { id: '1', username: 'johndoe' } as User;
+      mockUserRepo.findOne.mockResolvedValue(user);
+      const result = await userService.getUserByUsername('johndoe');
+      expect(result).toBe(user);
+      expect(mockUserRepo.findOne).toHaveBeenCalledWith({
+        where: { username: 'johndoe' },
+      });
+    });
+
+    it('should return null if user not found', async () => {
+      mockUserRepo.findOne.mockResolvedValue(null);
+      const result = await userService.getUserByUsername('nonexistent');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/tests/username.test.ts
+++ b/tests/username.test.ts
@@ -1,0 +1,134 @@
+import {
+  validateUsername,
+  canChangeUsername,
+  USERNAME_MIN_LENGTH,
+  USERNAME_MAX_LENGTH,
+} from '@/lib/username-validation';
+
+describe('validateUsername', () => {
+  it('should accept valid usernames', () => {
+    const validUsernames = [
+      'john_doe',
+      'jane-doe',
+      'user123',
+      'User_123',
+      'a_b-c',
+      'abc',
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+      'a'.repeat(30),
+    ];
+
+    validUsernames.forEach((username) => {
+      const result = validateUsername(username);
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  it('should reject usernames that are too short', () => {
+    const shortUsernames = ['a', 'ab']; // lengths 1,2
+    shortUsernames.forEach((username) => {
+      const result = validateUsername(username);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('at least 3 characters');
+    });
+  });
+
+  it('should reject usernames that are too long', () => {
+    const longUsername = 'a'.repeat(31);
+    const result = validateUsername(longUsername);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('no more than 30 characters');
+  });
+
+  it('should reject usernames with invalid characters', () => {
+    const invalidUsernames = [
+      'john.doe', // dot not allowed
+      'john doe', // space
+      'john@doe', // @
+      'john#doe', // #
+      'john$doe', // $
+      'john%doe', // %
+    ];
+
+    invalidUsernames.forEach((username) => {
+      const result = validateUsername(username);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('only contain letters, numbers, underscores, and dashes');
+    });
+  });
+
+  it('should reject usernames with consecutive special characters', () => {
+    const invalidUsernames = [
+      'john__doe',
+      'john--doe',
+      'john_-doe',
+      'john-_doe',
+      '__start',
+      'end__',
+      'test--',
+    ];
+
+    invalidUsernames.forEach((username) => {
+      const result = validateUsername(username);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('consecutive special characters');
+    });
+  });
+
+  it('should reject empty or whitespace-only usernames', () => {
+    const emptyCases = ['', '   ', null, undefined];
+    emptyCases.forEach((username) => {
+      const result = validateUsername(username as any);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Username is required');
+    });
+  });
+
+  it('should trim whitespace from username', () => {
+    const result = validateUsername('  john_doe  ');
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('canChangeUsername', () => {
+  it('should allow change if never changed before', () => {
+    const result = canChangeUsername(null);
+    expect(result.canChange).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('should allow change if last change was more than 30 days ago', () => {
+    const thirtyOneDaysAgo = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000);
+    const result = canChangeUsername(thirtyOneDaysAgo);
+    expect(result.canChange).toBe(true);
+  });
+
+  it('should deny change if within cooldown period', () => {
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    const result = canChangeUsername(tenDaysAgo);
+    expect(result.canChange).toBe(false);
+    expect(result.reason).toContain('30 days');
+    expect(result.remainingDays).toBeGreaterThan(0);
+    expect(result.remainingDays).toBeLessThanOrEqual(20);
+  });
+
+  it('should return exact remaining days', () => {
+    // Exactly 29 days remaining
+    const oneDayAgo = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000);
+    const result = canChangeUsername(oneDayAgo);
+    expect(result.remainingDays).toBe(29);
+  });
+
+  it('should allow change exactly at cooldown boundary', () => {
+    const exactly30DaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const result = canChangeUsername(exactly30DaysAgo);
+    // Because of milliseconds precision, may be at boundary exactly
+    // Either allowed or remainingDays = 0, but let's be tolerant.
+    if (!result.canChange) {
+      expect(result.remainingDays).toBe(0);
+    } else {
+      expect(result.canChange).toBe(true);
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,6 +46,9 @@
       ],
       "@/guards/*": [
         "./src/guards/*"
+      ],
+      "@/services/*": [
+        "./src/services/*"
       ]
     },
     "experimentalDecorators": true,


### PR DESCRIPTION
# CLOSES #380

All tasks completed successfully.

## Summary of Changes

### 1. User Entity
- Added `username` (unique, nullable, 30 chars) and `displayName` (nullable, 50 chars) fields, plus `usernameChangedAt` timestamp.
- `@BeforeInsert` hook sets default `displayName` from email prefix.

File: `src/entities/User.entity.ts`

### 2. Database Migrations
- `AddUsernameAndDisplayNameToUsersTable1714260000000.ts`: Adds columns and partial unique index.
- `CreateAuditLogsTable1714260000001.ts`: Creates `audit_logs` table for tracking changes.

### 3. Core Services & Validation
- `src/lib/username-validation.ts`: Validates format (alphanumeric, underscores, dashes; 3-30 chars; no consecutive special chars) and cooldown logic.
- `src/services/user.service.ts`: Encapsulates username availability, change with audit logging, and user lookup.

### 4. API Endpoints
- `GET /api/user/username/available` — checks availability with format validation.
- `PATCH /api/user/username` — updates username (authenticated), enforces validation, uniqueness, 30-day cooldown, and writes to audit log.
- `GET /api/users/me` — now returns `username`, `displayName`, and `usernameChangedAt`.
- `app/(public)/profiles/[username]/page.tsx` — public profile page reachable via `/profiles/:username`.

### 5. Tests
- `tests/username.test.ts`: Unit tests for validation rules and cooldown calculation.
- `tests/user-service.test.ts`: Unit tests for service methods (availability check, change logic) with mocked repositories.

### 6. Configuration
- Added `@/services/*` path mapping in `tsconfig.json`.
- Updated imports throughout to use the new service.

All tests pass (51 total). TypeScript typecheck and lint pass.

# PR for USERNAME support issue, PR numba #284