### PR TITLE
fix: responsive grids, view-all links, search filtering, loading skeletons

### DIFF
--- a/app/(public)/learning-resources/loading.tsx
+++ b/app/(public)/learning-resources/loading.tsx
@@ -1,0 +1,37 @@
+import { LearningTrackCardSkeleton, ArticleListItemSkeleton, QuickAccessCardSkeleton } from '@/components/LoadingSkeletons';
+
+export default function Loading() {
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      {/* Quick Access Skeletons */}
+      <div className="mb-10">
+        <div className="h-6 w-32 bg-gray-200 rounded animate-pulse mb-6" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <QuickAccessCardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+
+      {/* Learning Track Skeletons */}
+      <div className="mb-10">
+        <div className="h-6 w-48 bg-gray-200 rounded animate-pulse mb-6" />
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <LearningTrackCardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+
+      {/* Article Skeletons */}
+      <div>
+        <div className="h-6 w-40 bg-gray-200 rounded animate-pulse mb-6" />
+        <div className="space-y-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <ArticleListItemSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(public)/learning-resources/page.tsx
+++ b/app/(public)/learning-resources/page.tsx
@@ -1,59 +1,17 @@
 import ResourcesFooter from '@/components/ResourcesFooter';
 import ResourcesHero from '@/components/ResourcesHero';
-import dynamic from 'next/dynamic';
-import { Laptop, Wrench, BarChart3, Cloud, Palette, Users } from 'lucide-react';
-
-// Dynamically import the card component for code splitting
-const ResourceCategoryCard = dynamic(
-  () => import('@/components/ResourceCategoryCard'),
-  { loading: () => <CardSkeleton /> }
-);
-
-const categories = [
-  { title: 'Frontend Development', description: 'React, Next.js, CSS, and modern UI tooling.', icon: Laptop, link: '/learning-resources/frontend' },
-  { title: 'Backend Engineering', description: 'Node.js, databases, APIs, and server architecture.', icon: Wrench, link: '/learning-resources/backend' },
-  { title: 'Data Science', description: 'Python, statistics, and machine learning fundamentals.', icon: BarChart3, link: '/learning-resources/data-science' },
-  { title: 'DevOps & Cloud', description: 'CI/CD, Docker, Kubernetes, and cloud platforms.', icon: Cloud, link: '/learning-resources/devops' },
-  { title: 'Design & UX', description: 'Figma, user research, and design systems.', icon: Palette, link: '/learning-resources/design' },
-  { title: 'Soft Skills', description: 'Communication, leadership, and career growth.', icon: Users, link: '/learning-resources/soft-skills' },
-];
+import ResourcesContent from '@/components/ResourcesContent';
 
 export const metadata = {
   title: 'Learning Resources | SkillSync',
   description: 'Browse curated learning resources by category.',
 };
 
-function CardSkeleton() {
-  return (
-    <div className="flex flex-col items-center text-center bg-white rounded-xl p-5 shadow-sm border border-gray-100 animate-pulse">
-      <div className="w-8 h-8 bg-gray-200 rounded-full mb-3" />
-      <div className="w-24 h-4 bg-gray-200 rounded mb-2" />
-      <div className="w-32 h-3 bg-gray-100 rounded" />
-    </div>
-  );
-}
-
 export default function LearningResourcesPage() {
   return (
     <>
       <ResourcesHero />
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <header className="mb-10">
-          <h2 className="text-3xl font-bold text-gray-900">Browse by Category</h2>
-          <p className="mt-2 text-gray-500 text-base">
-            Explore hand-picked resources to grow your skills across all disciplines.
-          </p>
-        </header>
-
-        <section aria-labelledby="resource-categories">
-          <h2 id="resource-categories" className="sr-only">Resource Categories</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6" role="grid" aria-label="Learning resource categories">
-            {categories.map((cat) => (
-              <ResourceCategoryCard key={cat.link} {...cat} />
-            ))}
-          </div>
-        </section>
-      </main>
+      <ResourcesContent />
       <ResourcesFooter />
     </>
   );

--- a/app/(public)/resources/articles/page.tsx
+++ b/app/(public)/resources/articles/page.tsx
@@ -1,0 +1,45 @@
+import { Metadata } from 'next';
+import ArticleListItem from '@/components/ArticleListItem';
+
+export const metadata: Metadata = {
+  title: 'Articles | SkillSync',
+  description: 'Browse all articles on SkillSync.',
+};
+
+const articles = [
+  {
+    category: 'Development',
+    title: 'Getting Started with Next.js App Router',
+    author: 'Jane Doe',
+    readTime: '5 min read',
+    href: '/articles/nextjs-app-router',
+    isTrending: true,
+  },
+  {
+    category: 'Design',
+    title: 'Mastering Figma for UI/UX Designers',
+    author: 'John Smith',
+    readTime: '8 min read',
+    href: '/articles/figma-ui-ux',
+  },
+  {
+    category: 'Data Science',
+    title: 'Introduction to Machine Learning with Python',
+    author: 'Alice Johnson',
+    readTime: '10 min read',
+    href: '/articles/ml-python-intro',
+  },
+];
+
+export default function ArticlesPage() {
+  return (
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <h1 className="text-3xl font-bold text-gray-900 mb-8">All Articles</h1>
+      <div className="space-y-4">
+        {articles.map((article, index) => (
+          <ArticleListItem key={index} {...article} />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/(public)/resources/tracks/page.tsx
+++ b/app/(public)/resources/tracks/page.tsx
@@ -1,0 +1,59 @@
+import { Metadata } from 'next';
+import LearningTrackCard from '@/components/LearningTrackCard';
+
+export const metadata: Metadata = {
+  title: 'Learning Tracks | SkillSync',
+  description: 'Browse all learning tracks on SkillSync.',
+};
+
+const tracks = [
+  {
+    id: '1',
+    imageSrc: '/learning-tracks/full-stack.svg',
+    title: 'Full-Stack Development',
+    description: 'Master frontend and backend technologies to build complete web applications.',
+    category: 'Development',
+    lessonCount: 24,
+    duration: '12 weeks',
+  },
+  {
+    id: '2',
+    imageSrc: '/learning-tracks/data-science.svg',
+    title: 'Data Science & AI',
+    description: 'Learn Python, machine learning, and data visualization techniques.',
+    category: 'Data Science',
+    lessonCount: 30,
+    duration: '16 weeks',
+  },
+  {
+    id: '3',
+    imageSrc: '/learning-tracks/design.svg',
+    title: 'UI/UX Design Masterclass',
+    description: 'Create stunning user interfaces and seamless user experiences.',
+    category: 'Design',
+    lessonCount: 18,
+    duration: '10 weeks',
+  },
+];
+
+export default function TracksPage() {
+  return (
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <h1 className="text-3xl font-bold text-gray-900 mb-8">All Learning Tracks</h1>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {tracks.map((track) => (
+          <LearningTrackCard
+            key={track.id}
+            category={track.category}
+            title={track.title}
+            description={track.description}
+            lessonCount={track.lessonCount}
+            duration={track.duration}
+            href={`/learning/${track.id}`}
+            imageSrc={track.imageSrc}
+          />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/components/FeaturedArticlesSection.tsx
+++ b/components/FeaturedArticlesSection.tsx
@@ -10,7 +10,7 @@ export interface FeaturedArticlesSectionProps {
 
 export default function FeaturedArticlesSection({
   articles,
-  viewAllHref = '/articles',
+  viewAllHref = '/resources/articles',
 }: FeaturedArticlesSectionProps) {
   return (
     <section className="w-full">

--- a/components/FeaturedLearningTracks.tsx
+++ b/components/FeaturedLearningTracks.tsx
@@ -58,7 +58,7 @@ export default function FeaturedLearningTracks() {
             </p>
           </div>
           <Link
-            href="/learning-resources"
+            href="/resources/tracks"
             className="inline-flex items-center font-medium text-blue-600 transition-colors hover:text-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded px-2 py-1"
             aria-label="View all learning tracks"
           >
@@ -81,9 +81,9 @@ export default function FeaturedLearningTracks() {
           </Link>
         </div>
 
-        <div className="-mx-4 flex gap-6 overflow-x-auto px-4 pb-2 sm:-mx-6 sm:px-6 md:mx-0 md:grid md:grid-cols-3 md:gap-6 md:overflow-visible md:px-0 md:pb-0" role="list" aria-label="Featured learning tracks">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6" role="list" aria-label="Featured learning tracks">
           {tracks.map((track) => (
-            <div key={track.id} className="min-w-[280px] flex-none md:min-w-0 md:flex-auto" role="listitem">
+            <div key={track.id} role="listitem">
               <LearningTrackCard
                 category={track.category}
                 title={track.title}

--- a/components/LearningTrackCard.tsx
+++ b/components/LearningTrackCard.tsx
@@ -24,7 +24,7 @@ export default function LearningTrackCard({
   imageAlt,
 }: LearningTrackCardProps) {
   return (
-    <article className="group flex h-full w-full overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl">
+    <article className="group flex flex-col h-full w-full overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl">
       <div className="relative aspect-[4/3] overflow-hidden bg-slate-100">
         <Image
           src={imageSrc}

--- a/components/LoadingSkeletons.tsx
+++ b/components/LoadingSkeletons.tsx
@@ -1,0 +1,42 @@
+export function LearningTrackCardSkeleton() {
+  return (
+    <div className="flex flex-col h-full w-full overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm animate-pulse">
+      <div className="aspect-[4/3] bg-slate-200" />
+      <div className="flex flex-col p-6 gap-3">
+        <div className="flex gap-4">
+          <div className="h-4 w-20 bg-slate-200 rounded" />
+          <div className="h-4 w-16 bg-slate-200 rounded" />
+        </div>
+        <div className="h-5 w-3/4 bg-slate-200 rounded" />
+        <div className="h-4 w-full bg-slate-100 rounded" />
+        <div className="h-4 w-5/6 bg-slate-100 rounded" />
+        <div className="mt-auto pt-4 h-10 w-full bg-slate-200 rounded-xl" />
+      </div>
+    </div>
+  );
+}
+
+export function ArticleListItemSkeleton() {
+  return (
+    <div className="flex items-start gap-4 rounded-xl border border-slate-200 bg-white p-5 shadow-sm animate-pulse">
+      <div className="flex flex-1 flex-col gap-2">
+        <div className="h-5 w-16 bg-blue-100 rounded-full" />
+        <div className="h-5 w-3/4 bg-slate-200 rounded" />
+        <div className="flex gap-3">
+          <div className="h-4 w-20 bg-slate-100 rounded" />
+          <div className="h-4 w-16 bg-slate-100 rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function QuickAccessCardSkeleton() {
+  return (
+    <div className="flex flex-col items-center text-center bg-white rounded-xl p-5 shadow-sm border border-gray-100 animate-pulse">
+      <div className="w-8 h-8 bg-gray-200 rounded-full mb-3" />
+      <div className="w-24 h-4 bg-gray-200 rounded mb-2" />
+      <div className="w-32 h-3 bg-gray-100 rounded" />
+    </div>
+  );
+}

--- a/components/QuickAccessSection.tsx
+++ b/components/QuickAccessSection.tsx
@@ -21,7 +21,7 @@ export default function QuickAccessSection() {
     <section className="w-full py-10 bg-gray-50" aria-labelledby="quick-access-heading">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <h2 id="quick-access-heading" className="text-xl font-semibold text-gray-800 mb-6">Quick Access</h2>
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4" role="navigation" aria-label="Quick access navigation">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4" role="navigation" aria-label="Quick access navigation">
           {quickAccessItems.map((item) => (
             <ResourceCategoryCard
               key={item.link}

--- a/components/ResourcesContent.tsx
+++ b/components/ResourcesContent.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import dynamic from 'next/dynamic';
+import { Laptop, Wrench, BarChart3, Cloud, Palette, Users } from 'lucide-react';
+import ResourceSearchBar from '@/components/ResourceSearchBar';
+import FeaturedLearningTracks from '@/components/FeaturedLearningTracks';
+import FeaturedArticlesSection from '@/components/FeaturedArticlesSection';
+import QuickAccessSection from '@/components/QuickAccessSection';
+import ToolsAndTemplatesSection from '@/components/sections/ToolsAndTemplatesSection';
+import { ArticleListItemProps } from '@/components/ArticleListItem';
+
+const ResourceCategoryCard = dynamic(
+  () => import('@/components/ResourceCategoryCard'),
+  { loading: () => <CardSkeleton /> }
+);
+
+const categories = [
+  { title: 'Frontend Development', description: 'React, Next.js, CSS, and modern UI tooling.', icon: Laptop, link: '/learning-resources/frontend' },
+  { title: 'Backend Engineering', description: 'Node.js, databases, APIs, and server architecture.', icon: Wrench, link: '/learning-resources/backend' },
+  { title: 'Data Science', description: 'Python, statistics, and machine learning fundamentals.', icon: BarChart3, link: '/learning-resources/data-science' },
+  { title: 'DevOps & Cloud', description: 'CI/CD, Docker, Kubernetes, and cloud platforms.', icon: Cloud, link: '/learning-resources/devops' },
+  { title: 'Design & UX', description: 'Figma, user research, and design systems.', icon: Palette, link: '/learning-resources/design' },
+  { title: 'Soft Skills', description: 'Communication, leadership, and career growth.', icon: Users, link: '/learning-resources/soft-skills' },
+];
+
+const sampleArticles: ArticleListItemProps[] = [
+  { category: 'Development', title: 'Getting Started with Next.js App Router', author: 'Jane Doe', readTime: '5 min read', href: '/articles/nextjs-app-router', isTrending: true },
+  { category: 'Design', title: 'Mastering Figma for UI/UX Designers', author: 'John Smith', readTime: '8 min read', href: '/articles/figma-ui-ux' },
+  { category: 'Data Science', title: 'Introduction to Machine Learning with Python', author: 'Alice Johnson', readTime: '10 min read', href: '/articles/ml-python-intro' },
+];
+
+function CardSkeleton() {
+  return (
+    <div className="flex flex-col items-center text-center bg-white rounded-xl p-5 shadow-sm border border-gray-100 animate-pulse">
+      <div className="w-8 h-8 bg-gray-200 rounded-full mb-3" />
+      <div className="w-24 h-4 bg-gray-200 rounded mb-2" />
+      <div className="w-32 h-3 bg-gray-100 rounded" />
+    </div>
+  );
+}
+
+export default function ResourcesContent() {
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(query), 300);
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  const filteredCategories = debouncedQuery
+    ? categories.filter(
+        (c) =>
+          c.title.toLowerCase().includes(debouncedQuery.toLowerCase()) ||
+          c.description.toLowerCase().includes(debouncedQuery.toLowerCase())
+      )
+    : categories;
+
+  const filteredArticles = debouncedQuery
+    ? sampleArticles.filter(
+        (a) =>
+          a.title.toLowerCase().includes(debouncedQuery.toLowerCase()) ||
+          a.category.toLowerCase().includes(debouncedQuery.toLowerCase()) ||
+          a.author.toLowerCase().includes(debouncedQuery.toLowerCase())
+      )
+    : sampleArticles;
+
+  const hasResults = filteredCategories.length > 0 || filteredArticles.length > 0;
+
+  return (
+    <>
+      <div className="py-6">
+        <ResourceSearchBar onSearch={setQuery} />
+      </div>
+
+      {debouncedQuery ? (
+        <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          {!hasResults ? (
+            <p className="text-gray-500 text-center py-12">No results found for &ldquo;{debouncedQuery}&rdquo;</p>
+          ) : (
+            <>
+              {filteredCategories.length > 0 && (
+                <section className="mb-10" aria-labelledby="filtered-categories">
+                  <h2 id="filtered-categories" className="text-xl font-semibold text-gray-800 mb-4">Categories</h2>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {filteredCategories.map((cat) => (
+                      <ResourceCategoryCard key={cat.link} {...cat} />
+                    ))}
+                  </div>
+                </section>
+              )}
+              {filteredArticles.length > 0 && (
+                <section aria-labelledby="filtered-articles">
+                  <h2 id="filtered-articles" className="text-xl font-semibold text-gray-800 mb-4">Articles</h2>
+                  <FeaturedArticlesSection articles={filteredArticles} />
+                </section>
+              )}
+            </>
+          )}
+        </main>
+      ) : (
+        <>
+          <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+            <header className="mb-10">
+              <h2 className="text-3xl font-bold text-gray-900">Browse by Category</h2>
+              <p className="mt-2 text-gray-500 text-base">
+                Explore hand-picked resources to grow your skills across all disciplines.
+              </p>
+            </header>
+            <section aria-labelledby="resource-categories">
+              <h2 id="resource-categories" className="sr-only">Resource Categories</h2>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6" role="grid" aria-label="Learning resource categories">
+                {categories.map((cat) => (
+                  <ResourceCategoryCard key={cat.link} {...cat} />
+                ))}
+              </div>
+            </section>
+          </main>
+          <QuickAccessSection />
+          <FeaturedLearningTracks />
+          <FeaturedArticlesSection articles={sampleArticles} />
+          <ToolsAndTemplatesSection />
+        </>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Closes #261
Closes #262
Closes #263
Closes #264

## Changes

**#261 – Responsive Grid Behavior**
- `QuickAccessSection`: `grid-cols-1 sm:grid-cols-2 lg:grid-cols-4` (4→2→1)
- `FeaturedLearningTracks`: `grid-cols-1 md:grid-cols-3` (3→1), removed horizontal scroll
- `LearningTrackCard`: changed to `flex-col` so cards render correctly in a grid
- `ToolsAndTemplatesSection` already uses `grid-cols-1 md:grid-cols-2` ✓

**#262 – "View All" Navigation Links**
- `FeaturedLearningTracks` View All → `/resources/tracks`
- `FeaturedArticlesSection` default `viewAllHref` → `/resources/articles`
- Added `app/(public)/resources/tracks/page.tsx` and `app/(public)/resources/articles/page.tsx`

**#263 – Search Filtering Logic**
- New `ResourcesContent` client component wraps the page content
- 300ms debounced search via `useEffect`
- Case-insensitive filtering of categories and articles
- `LearningResourcesPage` stays a server component (keeps `metadata` export)

**#264 – Loading Skeletons**
- New `LoadingSkeletons.tsx`: `LearningTrackCardSkeleton`, `ArticleListItemSkeleton`, `QuickAccessCardSkeleton` — all use `animate-pulse`
- `app/(public)/learning-resources/loading.tsx` renders all three skeleton types during page load