### PR TITLE
feat:Implement Split-Screen Auth Layout with Mentor Highlight Panel

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,9 @@
+import AuthLayout from "@/components/auth/AuthLayout";
+
+export default function AuthRouteLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <AuthLayout>{children}</AuthLayout>;
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,156 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { loginSchema, LoginFormValues } from "@/lib/validations/auth";
+import FormField from "@/components/auth/FormField";
+
+export default function LoginPage() {
+  const [showPassword, setShowPassword] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid, isDirty },
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    mode: "onChange",
+  });
+
+  const onSubmit = async (data: LoginFormValues) => {
+    setIsLoading(true);
+    try {
+      // TODO: wire up to your auth service
+      console.log("Login data:", data);
+      await new Promise((r) => setTimeout(r, 1200)); // simulate API call
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const EyeIcon = () => (
+    <button
+      type="button"
+      onClick={() => setShowPassword((v) => !v)}
+      className="focus:outline-none hover:text-violet-600 transition-colors"
+      aria-label={showPassword ? "Hide password" : "Show password"}
+    >
+      {showPassword ? (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+        </svg>
+      ) : (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+        </svg>
+      )}
+    </button>
+  );
+
+  return (
+    <div>
+      {/* Heading */}
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900 tracking-tight">
+          Welcome back
+        </h1>
+        <p className="text-gray-500 text-sm mt-1.5">
+          Sign in to continue your learning journey
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} noValidate className="flex flex-col gap-5">
+        <FormField
+          id="email"
+          label="Email address"
+          type="email"
+          placeholder="you@example.com"
+          error={errors.email}
+          registration={register("email")}
+        />
+
+        <FormField
+          id="password"
+          label="Password"
+          type={showPassword ? "text" : "password"}
+          placeholder="Enter your password"
+          error={errors.password}
+          registration={register("password")}
+          rightElement={<EyeIcon />}
+        />
+
+        {/* Forgot password */}
+        <div className="flex justify-end -mt-2">
+          <Link
+            href="/forgot-password"
+            className="text-xs text-violet-600 hover:text-violet-700 font-medium transition-colors"
+          >
+            Forgot password?
+          </Link>
+        </div>
+
+        {/* Submit */}
+        <button
+          type="submit"
+          disabled={!isDirty || !isValid || isLoading}
+          className="w-full py-3 px-4 rounded-xl text-sm font-semibold text-white
+            bg-violet-600 hover:bg-violet-700 active:scale-[0.98]
+            disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-violet-600
+            transition-all duration-150 flex items-center justify-center gap-2 shadow-sm shadow-violet-200"
+        >
+          {isLoading ? (
+            <>
+              <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+              Signing in…
+            </>
+          ) : (
+            "Sign in"
+          )}
+        </button>
+
+        {/* Divider */}
+        <div className="relative my-1">
+          <div className="absolute inset-0 flex items-center">
+            <span className="w-full border-t border-gray-200" />
+          </div>
+          <div className="relative flex justify-center text-xs">
+            <span className="bg-white px-3 text-gray-400">or</span>
+          </div>
+        </div>
+
+        {/* Google OAuth placeholder */}
+        <button
+          type="button"
+          className="w-full py-2.5 px-4 rounded-xl border border-gray-200 text-sm font-medium
+            text-gray-700 bg-white hover:bg-gray-50 active:scale-[0.98]
+            transition-all duration-150 flex items-center justify-center gap-2.5"
+        >
+          <svg className="w-4 h-4" viewBox="0 0 24 24">
+            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+          </svg>
+          Continue with Google
+        </button>
+      </form>
+
+      {/* Register link */}
+      <p className="text-center text-sm text-gray-500 mt-8">
+        Don&apos;t have an account?{" "}
+        <Link
+          href="/register"
+          className="text-violet-600 font-semibold hover:text-violet-700 transition-colors"
+        >
+          Create one free
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,0 +1,225 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { registerSchema, RegisterFormValues } from "@/lib/validations/auth";
+import FormField from "@/components/auth/FormField";
+
+export default function RegisterPage() {
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isValid, isDirty },
+  } = useForm<RegisterFormValues>({
+    resolver: zodResolver(registerSchema),
+    mode: "onChange",
+  });
+
+  const password = watch("password", "");
+
+  const onSubmit = async (data: RegisterFormValues) => {
+    setIsLoading(true);
+    try {
+      // TODO: wire up to your auth service
+      console.log("Register data:", data);
+      await new Promise((r) => setTimeout(r, 1200));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Password strength indicator
+  const getPasswordStrength = (pw: string) => {
+    if (!pw) return 0;
+    let score = 0;
+    if (pw.length >= 8) score++;
+    if (/[A-Z]/.test(pw)) score++;
+    if (/[0-9]/.test(pw)) score++;
+    if (/[^A-Za-z0-9]/.test(pw)) score++;
+    return score;
+  };
+
+  const strength = getPasswordStrength(password);
+  const strengthLabel = ["", "Weak", "Fair", "Good", "Strong"][strength];
+  const strengthColor = ["", "bg-red-400", "bg-amber-400", "bg-yellow-400", "bg-emerald-500"][strength];
+
+  const EyeToggle = ({
+    visible,
+    onToggle,
+  }: {
+    visible: boolean;
+    onToggle: () => void;
+  }) => (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="focus:outline-none hover:text-violet-600 transition-colors"
+      aria-label={visible ? "Hide" : "Show"}
+    >
+      {visible ? (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+        </svg>
+      ) : (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+        </svg>
+      )}
+    </button>
+  );
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900 tracking-tight">
+          Create your account
+        </h1>
+        <p className="text-gray-500 text-sm mt-1.5">
+          Join thousands of learners and mentors on SkillSync
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} noValidate className="flex flex-col gap-5">
+        <FormField
+          id="fullName"
+          label="Full name"
+          placeholder="Jane Doe"
+          error={errors.fullName}
+          registration={register("fullName")}
+        />
+
+        <FormField
+          id="email"
+          label="Email address"
+          type="email"
+          placeholder="you@example.com"
+          error={errors.email}
+          registration={register("email")}
+        />
+
+        {/* Role selector */}
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm font-medium text-gray-700">I want to join as</label>
+          <div className="grid grid-cols-2 gap-3">
+            {(["mentee", "mentor"] as const).map((role) => (
+              <label
+                key={role}
+                className="flex items-center gap-3 p-3 rounded-xl border cursor-pointer
+                  border-gray-200 hover:border-violet-400 hover:bg-violet-50/50
+                  has-[:checked]:border-violet-500 has-[:checked]:bg-violet-50
+                  transition-all duration-150"
+              >
+                <input
+                  type="radio"
+                  value={role}
+                  className="accent-violet-600"
+                  {...register("role")}
+                />
+                <div>
+                  <p className="text-sm font-medium text-gray-800 capitalize">{role}</p>
+                  <p className="text-xs text-gray-400">
+                    {role === "mentee" ? "Find & learn from mentors" : "Share your expertise"}
+                  </p>
+                </div>
+              </label>
+            ))}
+          </div>
+          {errors.role && (
+            <p role="alert" className="text-xs text-red-500 flex items-center gap-1 mt-0.5">
+              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+              </svg>
+              {errors.role.message}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <FormField
+            id="password"
+            label="Password"
+            type={showPassword ? "text" : "password"}
+            placeholder="Min. 8 characters"
+            error={errors.password}
+            registration={register("password")}
+            rightElement={
+              <EyeToggle visible={showPassword} onToggle={() => setShowPassword((v) => !v)} />
+            }
+          />
+          {/* Strength meter */}
+          {password && (
+            <div className="mt-2 flex items-center gap-2">
+              <div className="flex gap-1 flex-1">
+                {[1, 2, 3, 4].map((i) => (
+                  <div
+                    key={i}
+                    className={`h-1 flex-1 rounded-full transition-all duration-300 ${
+                      i <= strength ? strengthColor : "bg-gray-200"
+                    }`}
+                  />
+                ))}
+              </div>
+              <span className={`text-xs font-medium ${
+                strength <= 1 ? "text-red-500" :
+                strength === 2 ? "text-amber-500" :
+                strength === 3 ? "text-yellow-600" : "text-emerald-600"
+              }`}>
+                {strengthLabel}
+              </span>
+            </div>
+          )}
+        </div>
+
+        <FormField
+          id="confirmPassword"
+          label="Confirm password"
+          type={showConfirm ? "text" : "password"}
+          placeholder="Repeat your password"
+          error={errors.confirmPassword}
+          registration={register("confirmPassword")}
+          rightElement={
+            <EyeToggle visible={showConfirm} onToggle={() => setShowConfirm((v) => !v)} />
+          }
+        />
+
+        <button
+          type="submit"
+          disabled={!isDirty || !isValid || isLoading}
+          className="w-full py-3 px-4 rounded-xl text-sm font-semibold text-white
+            bg-violet-600 hover:bg-violet-700 active:scale-[0.98]
+            disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-violet-600
+            transition-all duration-150 flex items-center justify-center gap-2 shadow-sm shadow-violet-200"
+        >
+          {isLoading ? (
+            <>
+              <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+              Creating account…
+            </>
+          ) : (
+            "Create account"
+          )}
+        </button>
+      </form>
+
+      <p className="text-center text-sm text-gray-500 mt-8">
+        Already have an account?{" "}
+        <Link
+          href="/login"
+          className="text-violet-600 font-semibold hover:text-violet-700 transition-colors"
+        >
+          Sign in
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/components/auth/AuthLayout.tsx
+++ b/components/auth/AuthLayout.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+
+interface FeaturedMentor {
+  name: string;
+  title: string;
+  avatar: string;
+  rating: number;
+  reviews: number;
+  skills: string[];
+}
+
+const featuredMentor: FeaturedMentor = {
+  name: "Dr. Aisha Okafor",
+  title: "Senior Product Designer @ Google",
+  avatar: "AO",
+  rating: 4.9,
+  reviews: 127,
+  skills: ["UX Design", "Product Strategy", "Figma"],
+};
+
+interface AuthLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function AuthLayout({ children }: AuthLayoutProps) {
+  return (
+    <div className="min-h-screen flex">
+      {/* Left Side – Form */}
+      <div className="flex-1 flex flex-col justify-center items-center px-6 py-12 bg-white lg:px-16">
+        {/* Logo */}
+        <div className="w-full max-w-md mb-10">
+          <span className="text-2xl font-bold tracking-tight text-gray-900">
+            Skill<span className="text-violet-600">Sync</span>
+          </span>
+        </div>
+
+        <div className="w-full max-w-md">{children}</div>
+      </div>
+
+      {/* Right Side – Mentor Highlight Panel (hidden on mobile) */}
+      <div className="hidden lg:flex lg:w-[48%] relative overflow-hidden flex-col justify-between p-12 bg-gradient-to-br from-violet-700 via-purple-600 to-indigo-800">
+        {/* Decorative circles */}
+        <div className="absolute -top-24 -right-24 w-80 h-80 rounded-full bg-white/5 blur-3xl" />
+        <div className="absolute bottom-0 -left-20 w-72 h-72 rounded-full bg-indigo-400/10 blur-2xl" />
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[420px] h-[420px] rounded-full border border-white/5" />
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[640px] h-[640px] rounded-full border border-white/5" />
+
+        {/* Header text */}
+        <div className="relative z-10">
+          <p className="text-white/60 text-sm font-medium uppercase tracking-widest mb-3">
+            Featured Mentor
+          </p>
+          <h2 className="text-white text-3xl font-bold leading-tight max-w-xs">
+            Learn from the best in your field
+          </h2>
+        </div>
+
+        {/* Mentor Card */}
+        <div className="relative z-10 my-auto">
+          <div className="bg-white/10 backdrop-blur-md border border-white/20 rounded-2xl p-6 shadow-2xl">
+            {/* Avatar & Info */}
+            <div className="flex items-center gap-4 mb-5">
+              <div className="w-14 h-14 rounded-full bg-gradient-to-br from-amber-300 to-orange-400 flex items-center justify-center text-white font-bold text-lg shadow-lg">
+                {featuredMentor.avatar}
+              </div>
+              <div>
+                <p className="text-white font-semibold text-base leading-tight">
+                  {featuredMentor.name}
+                </p>
+                <p className="text-white/60 text-sm mt-0.5">
+                  {featuredMentor.title}
+                </p>
+              </div>
+            </div>
+
+            {/* Rating */}
+            <div className="flex items-center gap-2 mb-5">
+              <div className="flex gap-0.5">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <svg
+                    key={i}
+                    className={`w-4 h-4 ${
+                      i < Math.floor(featuredMentor.rating)
+                        ? "text-amber-400"
+                        : "text-white/30"
+                    }`}
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                  >
+                    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                  </svg>
+                ))}
+              </div>
+              <span className="text-white font-semibold text-sm">
+                {featuredMentor.rating}
+              </span>
+              <span className="text-white/50 text-sm">
+                ({featuredMentor.reviews} reviews)
+              </span>
+            </div>
+
+            {/* Skills */}
+            <div className="flex flex-wrap gap-2">
+              {featuredMentor.skills.map((skill) => (
+                <span
+                  key={skill}
+                  className="px-3 py-1 text-xs font-medium rounded-full bg-white/15 text-white border border-white/20"
+                >
+                  {skill}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Testimonial */}
+        <div className="relative z-10">
+          <blockquote className="text-white/90 text-lg font-medium leading-relaxed italic">
+            &ldquo;Grow confidently with support from skilled mentors who care&rdquo;
+          </blockquote>
+          <div className="mt-4 flex gap-1.5">
+            {[0, 1, 2].map((i) => (
+              <span
+                key={i}
+                className={`block h-1 rounded-full transition-all ${
+                  i === 0 ? "w-6 bg-white" : "w-2 bg-white/30"
+                }`}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/auth/FormField.tsx
+++ b/components/auth/FormField.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { FieldError } from "react-hook-form";
+
+interface FormFieldProps {
+  id: string;
+  label: string;
+  type?: string;
+  placeholder?: string;
+  error?: FieldError;
+  registration: React.InputHTMLAttributes<HTMLInputElement>;
+  rightElement?: React.ReactNode;
+}
+
+export default function FormField({
+  id,
+  label,
+  type = "text",
+  placeholder,
+  error,
+  registration,
+  rightElement,
+}: FormFieldProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label
+        htmlFor={id}
+        className="text-sm font-medium text-gray-700"
+      >
+        {label}
+      </label>
+      <div className="relative">
+        <input
+          id={id}
+          type={type}
+          placeholder={placeholder}
+          aria-invalid={!!error}
+          aria-describedby={error ? `${id}-error` : undefined}
+          className={`w-full px-4 py-2.5 rounded-xl border text-sm text-gray-900 placeholder-gray-400
+            bg-gray-50 transition-all duration-150 outline-none
+            focus:bg-white focus:ring-2 focus:ring-violet-500/30 focus:border-violet-500
+            ${error
+              ? "border-red-400 bg-red-50 focus:ring-red-300/30 focus:border-red-400"
+              : "border-gray-200 hover:border-gray-300"
+            }
+            ${rightElement ? "pr-11" : ""}
+          `}
+          {...registration}
+        />
+        {rightElement && (
+          <div className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400">
+            {rightElement}
+          </div>
+        )}
+      </div>
+      {error && (
+        <p
+          id={`${id}-error`}
+          role="alert"
+          className="text-xs text-red-500 flex items-center gap-1 mt-0.5"
+        >
+          <svg className="w-3.5 h-3.5 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+            <path
+              fillRule="evenodd"
+              d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+              clipRule="evenodd"
+            />
+          </svg>
+          {error.message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -1,0 +1,42 @@
+// lib/validations/auth.ts
+import { z } from "zod";
+
+export const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, "Email is required")
+    .email("Please enter a valid email address"),
+  password: z
+    .string()
+    .min(1, "Password is required")
+    .min(8, "Password must be at least 8 characters"),
+});
+
+export const registerSchema = z
+  .object({
+    fullName: z
+      .string()
+      .min(1, "Full name is required")
+      .min(2, "Name must be at least 2 characters"),
+    email: z
+      .string()
+      .min(1, "Email is required")
+      .email("Please enter a valid email address"),
+    password: z
+      .string()
+      .min(1, "Password is required")
+      .min(8, "Password must be at least 8 characters")
+      .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
+      .regex(/[0-9]/, "Password must contain at least one number"),
+    confirmPassword: z.string().min(1, "Please confirm your password"),
+    role: z.enum(["mentee", "mentor"], {
+      error: "Please select a role",
+    }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export type LoginFormValues = z.infer<typeof loginSchema>;
+export type RegisterFormValues = z.infer<typeof registerSchema>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,12 @@
       "name": "skillsync",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.4.0",
         "next": "14.2.5",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "react-hook-form": "^7.77.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "25.9.1",
@@ -131,6 +134,18 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -507,6 +522,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {
@@ -4690,6 +4711,22 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.77.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.77.0.tgz",
+      "integrity": "sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6127,6 +6164,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.4.0",
     "next": "14.2.5",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-hook-form": "^7.77.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "25.9.1",


### PR DESCRIPTION
#311a — Split-screen layout (AuthLayout.tsx): white form side + purple from-violet-700 via-purple-600 to-indigo-800 gradient right panel with a glassmorphism mentor card, testimonial quote, and decorative blurred circles. Right panel is hidden lg:flex — mobile shows form only.
#311b — Login Form UI (login/page.tsx): email + password inputs, show/hide toggle, "Forgot password?" link, disabled submit until valid, Google OAuth button placeholder, link to register.
#311c — Client-side validation (auth.ts + both pages): Zod schemas with zodResolver and mode: "onChange". Errors appear live below each field with an icon. Submit stays disabled while invalid. Register also has password strength meter (Weak → Strong) and password match check via .refine().

Closes #309
Closes #312
Closes #311