### PR TITLE
fix: improve responsive grid behavior on resources page

### DIFF
--- a/components/resources/FeaturedLearningTracksSection.tsx
+++ b/components/resources/FeaturedLearningTracksSection.tsx
@@ -46,7 +46,7 @@ export default function FeaturedLearningTracksSection() {
           View All &rarr;
         </Link>
       </div>
-      <div className="mt-6 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
         {featuredTracks.map((track) => (
           <LearningTrackCard key={track.title} {...track} />
         ))}

--- a/components/resources/QuickAccessSection.tsx
+++ b/components/resources/QuickAccessSection.tsx
@@ -52,7 +52,7 @@ export default function QuickAccessSection() {
     <section>
       <h2 className="text-2xl font-semibold text-slate-900">Quick Access</h2>
       <p className="mt-2 text-sm text-slate-600">Jump into popular resource categories</p>
-      <div className="mt-6 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
         {quickAccessItems.map((item) => (
           <ResourceCategoryCard key={item.title} {...item} />
         ))}


### PR DESCRIPTION
- Quick Access: 4 columns → 2 columns → 1 column on mobile
- Learning Tracks: 3 columns → 1 column directly (removed md breakpoint)
- Tools section (Downloadable Tools card) stacks cleanly via grid collapse

No overflow, clean stacking at all breakpoints.

Closes #328