### PR TITLE
feat: Implement Mentor Search Functionality

### DIFF
--- a/components/landing/MentorDiscoverySection.tsx
+++ b/components/landing/MentorDiscoverySection.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useState } from 'react';
 import CategoryBadge from '../CategoryBadge';
+import MentorSearchBar from '../mentors/MentorSearchBar';
 
 const filters = ['All', 'Engineering', 'Design', 'Product', 'Business', 'Data'];
 
@@ -108,10 +109,19 @@ const mentors = [
 
 export default function MentorDiscoverySection() {
   const [activeFilter, setActiveFilter] = useState('All');
+  const [searchQuery, setSearchQuery] = useState('');
 
-  const filtered = activeFilter === 'All'
-    ? mentors
-    : mentors.filter(m => m.category === activeFilter);
+  const filtered = mentors.filter(m => {
+    const matchesFilter = activeFilter === 'All' || m.category === activeFilter;
+    const q = searchQuery.toLowerCase();
+    const matchesSearch =
+      !q ||
+      m.name.toLowerCase().includes(q) ||
+      m.role.toLowerCase().includes(q) ||
+      m.description.toLowerCase().includes(q) ||
+      m.tags.some(tag => tag.toLowerCase().includes(q));
+    return matchesFilter && matchesSearch;
+  });
 
   return (
     <section className="mentor-discovery">
@@ -461,6 +471,11 @@ export default function MentorDiscoverySection() {
           </Link>
         </div>
 
+        {/* Search */}
+        <div style={{ marginBottom: '24px' }}>
+          <MentorSearchBar onSearch={setSearchQuery} />
+        </div>
+
         {/* Filters */}
         <div className="md-filters">
           {filters.map(f => (
@@ -477,7 +492,11 @@ export default function MentorDiscoverySection() {
         {/* Grid */}
         <div className="md-grid">
           {filtered.length === 0 && (
-            <div className="md-empty">No mentors found in this category yet.</div>
+            <div className="md-empty">
+              {searchQuery
+                ? `No mentors match "${searchQuery}".`
+                : 'No mentors found in this category yet.'}
+            </div>
           )}
 
           {filtered.map(mentor => (

--- a/components/mentors/MentorSearchBar.tsx
+++ b/components/mentors/MentorSearchBar.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import React, { useState, useEffect, useRef } from 'react';
+
+interface MentorSearchBarProps {
+  onSearch?: (query: string) => void;
+  placeholder?: string;
+  debounceMs?: number;
+}
+
+export default function MentorSearchBar({
+  onSearch,
+  placeholder = 'Search by name, skills, or headline...',
+  debounceMs = 300,
+}: MentorSearchBarProps) {
+  const [query, setQuery] = useState('');
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!onSearch) return;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      onSearch(query.trim());
+    }, debounceMs);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [query, onSearch, debounceMs]);
+
+  return (
+    <div className="w-full">
+      <div className="relative">
+        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
+          <svg
+            className="h-5 w-5"
+            style={{ color: '#94928d' }}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+        </div>
+        <input
+          type="text"
+          value={query}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setQuery(e.target.value)}
+          placeholder={placeholder}
+          aria-label="Search mentors"
+          style={{
+            width: '100%',
+            borderRadius: '100px',
+            border: '1.5px solid rgba(20,18,16,0.15)',
+            background: '#fff',
+            padding: '11px 16px 11px 44px',
+            fontSize: '14px',
+            color: '#141210',
+            fontFamily: "'DM Sans', sans-serif",
+            outline: 'none',
+            transition: 'border-color 0.18s ease, box-shadow 0.18s ease',
+          }}
+          onFocus={(e) => {
+            e.currentTarget.style.borderColor = 'rgba(20,18,16,0.5)';
+            e.currentTarget.style.boxShadow = '0 0 0 3px rgba(20,18,16,0.06)';
+          }}
+          onBlur={(e) => {
+            e.currentTarget.style.borderColor = 'rgba(20,18,16,0.15)';
+            e.currentTarget.style.boxShadow = 'none';
+          }}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Integrates `MentorSearchBar` (from #363) into `MentorDiscoverySection`
- Adds a `searchQuery` state that receives the debounced value from the search bar
- Filters mentors dynamically by **name**, **skills** (tags), and **headline** (role/description)
- Category filter and search filter compose together (both must match)
- Empty state message is context-aware: shows the search term when no results are found

## Test plan

- [ ] Load the landing page and confirm the search bar appears above the category filters
- [ ] Type a mentor name (e.g. "Kwame") — confirm only matching cards are shown
- [ ] Type a skill (e.g. "Python") — confirm only mentors with that skill tag appear
- [ ] Type a role keyword (e.g. "Engineer") — confirm headline matching works
- [ ] Combine search with a category filter and verify both conditions apply
- [ ] Clear the search field and confirm all mentors for the active category are restored
- [ ] Type a query with no matches and verify the empty state message includes the search term

> **Note:** This PR includes the `MentorSearchBar` component introduced in #363. It is best merged after #363 is merged, but contains no conflicts with main.

Closes #364