### PR TITLE
feat: Create Mentor Discovery Route

### DIFF
--- a/app/(public)/mentors/page.tsx
+++ b/app/(public)/mentors/page.tsx
@@ -1,0 +1,12 @@
+export default function MentorsPage() {
+  return (
+    <main className="min-h-screen bg-[#f7f5f2]">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <h1 className="text-4xl font-bold text-[#141210]">Find Mentors</h1>
+        <p className="mt-3 text-[#6b6860]">
+          Connect with experienced professionals ready to guide your growth.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/components/navigation/Navbar.tsx
+++ b/components/navigation/Navbar.tsx
@@ -6,7 +6,7 @@ import { MenuIcon, XIcon } from "@/components/Icons";
 
 const NAV_LINKS = [
   { label: "Home", href: "/" },
-  { label: "Discover Mentors", href: "/discover" },
+  { label: "Find Mentors", href: "/mentors" },
   { label: "How It Works", href: "/how-it-works" },
   { label: "Pricing", href: "/pricing" },
 ];


### PR DESCRIPTION
## Summary

- Creates `app/(public)/mentors/page.tsx` — a new Next.js App Router page accessible at `/mentors` under the existing public layout (inherits `Navbar` + padding from `(public)/layout.tsx`)
- Updates the public `Navbar` nav link from `/discover` → `/mentors` with the label "Find Mentors" so the route is reachable from the site navigation on both desktop and mobile

## Test plan

- [ ] Navigate to `/mentors` — page loads without a 404
- [ ] Click "Find Mentors" in the desktop navbar — routes to `/mentors`
- [ ] Click "Find Mentors" in the mobile hamburger menu — routes to `/mentors` and closes the menu
- [ ] Active-link highlight applies on `/mentors`

Closes #361