### PR TITLE
feat: Create Mentor Discovery Page Layout

### DIFF
--- a/app/(public)/mentors/page.tsx
+++ b/app/(public)/mentors/page.tsx
@@ -1,12 +1,5 @@
+import MentorDiscoveryLayout from '@/components/mentors/MentorDiscoveryLayout';
+
 export default function MentorsPage() {
-  return (
-    <main className="min-h-screen bg-[#f7f5f2]">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-        <h1 className="text-4xl font-bold text-[#141210]">Find Mentors</h1>
-        <p className="mt-3 text-[#6b6860]">
-          Connect with experienced professionals ready to guide your growth.
-        </p>
-      </div>
-    </main>
-  );
+  return <MentorDiscoveryLayout />;
 }

--- a/components/mentors/MentorDiscoveryLayout.tsx
+++ b/components/mentors/MentorDiscoveryLayout.tsx
@@ -1,0 +1,358 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+const CATEGORIES = ['All', 'Engineering', 'Design', 'Product', 'Business', 'Data'];
+const AVAILABILITY = ['All', 'Available', 'Fully Booked'];
+
+type Mentor = {
+  id: number;
+  name: string;
+  role: string;
+  company: string;
+  category: string;
+  initials: string;
+  accent: string;
+  bg: string;
+  available: boolean;
+  rating: number;
+  sessions: number;
+  description: string;
+  tags: string[];
+};
+
+const mentors: Mentor[] = [
+  {
+    id: 1,
+    name: 'Kwame Asante',
+    role: 'Staff Engineer',
+    company: 'Stripe',
+    category: 'Engineering',
+    initials: 'KA',
+    accent: '#3b82f6',
+    bg: '#0f1f3d',
+    available: true,
+    rating: 4.95,
+    sessions: 204,
+    description:
+      'Helps engineers level up to Staff and beyond. Specialises in distributed systems, technical leadership, and promo packets.',
+    tags: ['System Design', 'Leadership', 'Go'],
+  },
+  {
+    id: 2,
+    name: 'Priya Menon',
+    role: 'Head of Product Design',
+    company: 'Figma',
+    category: 'Design',
+    initials: 'PM',
+    accent: '#a855f7',
+    bg: '#1e0f3d',
+    available: true,
+    rating: 4.98,
+    sessions: 187,
+    description:
+      'Portfolio reviews, design system strategy, and breaking into senior IC or management tracks at top-tier product companies.',
+    tags: ['Figma', 'Design Systems', 'Portfolio'],
+  },
+  {
+    id: 3,
+    name: 'Tomás Reyes',
+    role: 'Senior PM',
+    company: 'Notion',
+    category: 'Product',
+    initials: 'TR',
+    accent: '#10b981',
+    bg: '#0a2318',
+    available: false,
+    rating: 4.91,
+    sessions: 139,
+    description:
+      'From APM to PM to Group PM — Tomás has made every jump and guides others through the same transitions with precision.',
+    tags: ['Roadmapping', 'Stakeholders', 'APM'],
+  },
+  {
+    id: 4,
+    name: 'Aisha Nwosu',
+    role: 'Data Science Lead',
+    company: 'Spotify',
+    category: 'Data',
+    initials: 'AN',
+    accent: '#f59e0b',
+    bg: '#2a1800',
+    available: true,
+    rating: 4.93,
+    sessions: 256,
+    description:
+      'ML pipelines, A/B testing at scale, and transitioning from academia to industry. Obsessed with making data teams actually functional.',
+    tags: ['Python', 'ML', 'Analytics'],
+  },
+  {
+    id: 5,
+    name: 'Leon Fischer',
+    role: 'Founding Engineer',
+    company: '3× YC Startups',
+    category: 'Engineering',
+    initials: 'LF',
+    accent: '#ef4444',
+    bg: '#2a0a0a',
+    available: true,
+    rating: 4.89,
+    sessions: 98,
+    description:
+      'Zero to one builder. Helps early-career devs ship fast, make technical decisions under uncertainty, and navigate startup chaos.',
+    tags: ['React', 'Node', 'Startup'],
+  },
+  {
+    id: 6,
+    name: 'Sara Lindqvist',
+    role: 'VP of Growth',
+    company: 'Duolingo',
+    category: 'Business',
+    initials: 'SL',
+    accent: '#06b6d4',
+    bg: '#011f26',
+    available: false,
+    rating: 4.96,
+    sessions: 321,
+    description:
+      'Growth loops, retention mechanics, and go-to-market for consumer apps. Former founder. Brutally practical and candid.',
+    tags: ['Growth', 'GTM', 'Retention'],
+  },
+];
+
+function MentorCard({ mentor }: { mentor: Mentor }) {
+  return (
+    <div className="bg-white rounded-2xl border border-[rgba(20,18,16,0.07)] overflow-hidden flex flex-col transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_20px_48px_rgba(20,18,16,0.1)]">
+      {/* Top */}
+      <div className="p-6 flex items-start gap-4">
+        <div
+          className="w-14 h-14 rounded-[14px] flex-shrink-0 flex items-center justify-center text-lg font-bold relative"
+          style={{ background: mentor.bg, color: mentor.accent, fontFamily: "'Syne', sans-serif" }}
+        >
+          {mentor.initials}
+          <span
+            className={`absolute bottom-[-2px] right-[-2px] w-3 h-3 rounded-full border-2 border-white ${
+              mentor.available ? 'bg-emerald-500' : 'bg-gray-300'
+            }`}
+          />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <p className="font-bold text-[#141210] text-[15px] truncate" style={{ fontFamily: "'Syne', sans-serif" }}>
+            {mentor.name}
+          </p>
+          <p className="text-[13px] text-[#94928d] truncate">{mentor.role}</p>
+          <p className="text-[12px] font-medium mt-0.5" style={{ color: mentor.accent }}>
+            {mentor.company}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-1 bg-[#f7f5f2] rounded-lg px-2 py-1 flex-shrink-0">
+          <span className="text-amber-400 text-[11px]">★</span>
+          <span className="text-[12px] font-semibold text-[#141210]">{mentor.rating}</span>
+        </div>
+      </div>
+
+      <div className="h-px bg-[rgba(20,18,16,0.07)] mx-6" />
+
+      {/* Body */}
+      <div className="p-6 flex-1 flex flex-col gap-4">
+        <p className="text-[13.5px] leading-[1.7] text-[#6b6860] flex-1">{mentor.description}</p>
+        <div className="flex flex-wrap gap-1.5">
+          {mentor.tags.map(tag => (
+            <span
+              key={tag}
+              className="text-[11.5px] font-medium px-2.5 py-1 rounded-md bg-[#f7f5f2] text-[#6b6860] border border-[rgba(20,18,16,0.08)]"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="px-6 pb-6 flex items-center justify-between gap-3">
+        <span className="text-[12px] text-[#94928d]">
+          <strong className="text-[#141210] font-semibold">{mentor.sessions}</strong> sessions
+        </span>
+        <Link
+          href={mentor.available ? `/mentors/${mentor.id}` : '#'}
+          className={`text-[12.5px] font-semibold px-4 py-2 rounded-xl transition-all duration-200 ${
+            mentor.available
+              ? 'bg-[#141210] text-[#f7f5f2] hover:bg-[#2d2a27]'
+              : 'bg-[#f0efed] text-[#94928d] cursor-default pointer-events-none'
+          }`}
+          style={{ fontFamily: "'DM Sans', sans-serif" }}
+        >
+          {mentor.available ? 'Book session' : 'Fully booked'}
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function FilterPanel({
+  activeCategory,
+  setActiveCategory,
+  activeAvailability,
+  setActiveAvailability,
+}: {
+  activeCategory: string;
+  setActiveCategory: (v: string) => void;
+  activeAvailability: string;
+  setActiveAvailability: (v: string) => void;
+}) {
+  return (
+    <>
+      {/* Category */}
+      <div className="bg-white rounded-2xl p-5 border border-[rgba(20,18,16,0.07)]">
+        <h3 className="text-[13px] font-semibold text-[#141210] mb-3 uppercase tracking-wider">
+          Category
+        </h3>
+        <ul className="space-y-0.5">
+          {CATEGORIES.map(cat => (
+            <li key={cat}>
+              <button
+                onClick={() => setActiveCategory(cat)}
+                className={`w-full text-left text-[13px] px-3 py-2 rounded-lg transition-colors ${
+                  activeCategory === cat
+                    ? 'bg-[#141210] text-[#f7f5f2] font-medium'
+                    : 'text-[#6b6860] hover:bg-[#f7f5f2] hover:text-[#141210]'
+                }`}
+              >
+                {cat}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Availability */}
+      <div className="bg-white rounded-2xl p-5 border border-[rgba(20,18,16,0.07)] mt-4">
+        <h3 className="text-[13px] font-semibold text-[#141210] mb-3 uppercase tracking-wider">
+          Availability
+        </h3>
+        <ul className="space-y-0.5">
+          {AVAILABILITY.map(opt => (
+            <li key={opt}>
+              <button
+                onClick={() => setActiveAvailability(opt)}
+                className={`w-full text-left text-[13px] px-3 py-2 rounded-lg transition-colors ${
+                  activeAvailability === opt
+                    ? 'bg-[#141210] text-[#f7f5f2] font-medium'
+                    : 'text-[#6b6860] hover:bg-[#f7f5f2] hover:text-[#141210]'
+                }`}
+              >
+                {opt}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+}
+
+export default function MentorDiscoveryLayout() {
+  const [activeCategory, setActiveCategory] = useState('All');
+  const [activeAvailability, setActiveAvailability] = useState('All');
+
+  const filtered = mentors.filter(m => {
+    const matchesCategory = activeCategory === 'All' || m.category === activeCategory;
+    const matchesAvailability =
+      activeAvailability === 'All' ||
+      (activeAvailability === 'Available' && m.available) ||
+      (activeAvailability === 'Fully Booked' && !m.available);
+    return matchesCategory && matchesAvailability;
+  });
+
+  return (
+    <div className="min-h-screen bg-[#f7f5f2]">
+      {/* Page header */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 border-b border-[rgba(20,18,16,0.07)]">
+        <p className="text-[11px] font-medium tracking-[0.15em] uppercase text-[#94928d] mb-2">
+          Our Community
+        </p>
+        <h1
+          className="text-[clamp(28px,4vw,42px)] font-extrabold text-[#141210] leading-tight"
+          style={{ fontFamily: "'Syne', sans-serif" }}
+        >
+          Find your mentor
+        </h1>
+        <p className="mt-2 text-[15px] text-[#6b6860]">
+          Browse {mentors.length} experienced professionals ready to guide your journey.
+        </p>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Mobile filters (horizontal pills) */}
+        <div className="lg:hidden mb-6 space-y-3">
+          <div className="flex gap-2 overflow-x-auto pb-1">
+            {CATEGORIES.map(cat => (
+              <button
+                key={cat}
+                onClick={() => setActiveCategory(cat)}
+                className={`flex-shrink-0 text-[12.5px] font-medium px-4 py-2 rounded-full border transition-all ${
+                  activeCategory === cat
+                    ? 'bg-[#141210] text-[#f7f5f2] border-[#141210]'
+                    : 'text-[#6b6860] border-[rgba(20,18,16,0.15)] hover:border-[rgba(20,18,16,0.4)] hover:text-[#141210]'
+                }`}
+              >
+                {cat}
+              </button>
+            ))}
+          </div>
+          <div className="flex gap-2 overflow-x-auto pb-1">
+            {AVAILABILITY.map(opt => (
+              <button
+                key={opt}
+                onClick={() => setActiveAvailability(opt)}
+                className={`flex-shrink-0 text-[12.5px] font-medium px-4 py-2 rounded-full border transition-all ${
+                  activeAvailability === opt
+                    ? 'bg-[#141210] text-[#f7f5f2] border-[#141210]'
+                    : 'text-[#6b6860] border-[rgba(20,18,16,0.15)] hover:border-[rgba(20,18,16,0.4)] hover:text-[#141210]'
+                }`}
+              >
+                {opt}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Two-column layout */}
+        <div className="flex gap-8 items-start">
+          {/* Sidebar — hidden on mobile, sticky on desktop */}
+          <aside className="hidden lg:block w-56 flex-shrink-0 sticky top-20">
+            <FilterPanel
+              activeCategory={activeCategory}
+              setActiveCategory={setActiveCategory}
+              activeAvailability={activeAvailability}
+              setActiveAvailability={setActiveAvailability}
+            />
+          </aside>
+
+          {/* Mentor listing area */}
+          <main className="flex-1 min-w-0">
+            <p className="text-[13px] text-[#94928d] mb-5">
+              <span className="font-semibold text-[#141210]">{filtered.length}</span>{' '}
+              mentor{filtered.length !== 1 ? 's' : ''} found
+            </p>
+
+            {filtered.length === 0 ? (
+              <div className="text-center py-16 text-[#94928d] text-[15px]">
+                No mentors match the selected filters.
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-5">
+                {filtered.map(mentor => (
+                  <MentorCard key={mentor.id} mentor={mentor} />
+                ))}
+              </div>
+            )}
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `components/mentors/MentorDiscoveryLayout.tsx` — a self-contained two-column layout component for the `/mentors` discovery page
- Updates `app/(public)/mentors/page.tsx` (from #361) to render the full layout

### Layout structure

**Desktop (≥ 1024px):**
- Sticky left sidebar (`w-56`) with two filter panels: **Category** and **Availability**
- Right main area with a responsive mentor card grid (1 → 2 → 3 columns)

**Mobile (< 1024px):**
- Sidebar is hidden; filters become horizontally scrollable pill rows above the grid
- Full-width card grid (1 column on small, 2 on sm+)

### Other details
- Live result count updates as filters change
- Empty state message when no mentors match active filters
- Card design (avatar initials, accent colours, rating pill, skill tags, book button) is consistent with the rest of the design system

## Test plan

- [ ] Visit `/mentors` — page renders with sidebar and mentor cards
- [ ] Click a category in the sidebar — listing filters to that category only
- [ ] Click "Available" in the availability panel — only available mentors shown
- [ ] Combine category + availability filters — both conditions apply
- [ ] Reset to "All" in both panels — all 6 mentors visible
- [ ] Resize to < 1024px — sidebar disappears, horizontal pill rows appear
- [ ] On mobile, scroll the pill rows horizontally — all options reachable
- [ ] "Book session" links work; "Fully booked" button is non-interactive

> **Note:** This PR builds on #361. It is best merged after #361.

Closes #362