### PR TITLE
feat: add mentor availability badge with Available/Busy/Fully Booked …

### DIFF
--- a/components/mentors/AvailabilityBadge.tsx
+++ b/components/mentors/AvailabilityBadge.tsx
@@ -1,0 +1,42 @@
+export type AvailabilityStatus = 'available' | 'busy' | 'fully_booked';
+
+const config: Record<AvailabilityStatus, { label: string; dot: string; badge: string }> = {
+  available: {
+    label: 'Available',
+    dot: 'bg-emerald-500',
+    badge: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  },
+  busy: {
+    label: 'Busy',
+    dot: 'bg-amber-400',
+    badge: 'bg-amber-50 text-amber-700 border-amber-200',
+  },
+  fully_booked: {
+    label: 'Fully Booked',
+    dot: 'bg-red-400',
+    badge: 'bg-red-50 text-red-600 border-red-200',
+  },
+};
+
+type Props = {
+  status: AvailabilityStatus;
+  /** 'badge' renders a pill; 'dot' renders only the colored dot */
+  variant?: 'badge' | 'dot';
+};
+
+export default function AvailabilityBadge({ status, variant = 'badge' }: Props) {
+  const { label, dot, badge } = config[status];
+
+  if (variant === 'dot') {
+    return <span className={`inline-block w-2.5 h-2.5 rounded-full ${dot}`} aria-label={label} />;
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 text-[11.5px] font-medium px-2 py-0.5 rounded-full border ${badge}`}
+    >
+      <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${dot}`} />
+      {label}
+    </span>
+  );
+}

--- a/components/mentors/MentorDiscoveryLayout.tsx
+++ b/components/mentors/MentorDiscoveryLayout.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import FilterSidebar from '@/components/mentors/FilterSidebar';
+import AvailabilityBadge, { AvailabilityStatus } from '@/components/mentors/AvailabilityBadge';
 
 type Mentor = {
   id: number;
@@ -16,6 +17,7 @@ type Mentor = {
   bg: string;
   image?: string;
   available: boolean;
+  status?: AvailabilityStatus;
   rating: number;
   rate: number;
   sessions: number;
@@ -35,6 +37,7 @@ const mentors: Mentor[] = [
     bg: '#0f1f3d',
     image: '/tony-adebanjo.jpg',
     available: true,
+    status: 'available' as AvailabilityStatus,
     rating: 4.95,
     rate: 180,
     sessions: 204,
@@ -53,6 +56,7 @@ const mentors: Mentor[] = [
     bg: '#1e0f3d',
     image: '/Image (Sarah Johnson).svg',
     available: true,
+    status: 'busy' as AvailabilityStatus,
     rating: 4.98,
     rate: 145,
     sessions: 187,
@@ -71,6 +75,7 @@ const mentors: Mentor[] = [
     bg: '#0a2318',
     image: '/Image (Marcus Williams).svg',
     available: false,
+    status: 'fully_booked' as AvailabilityStatus,
     rating: 4.91,
     rate: 160,
     sessions: 139,
@@ -89,6 +94,7 @@ const mentors: Mentor[] = [
     bg: '#2a1800',
     image: '/Image (Cole Hathans).svg',
     available: true,
+    status: 'available' as AvailabilityStatus,
     rating: 4.93,
     rate: 155,
     sessions: 256,
@@ -107,6 +113,7 @@ const mentors: Mentor[] = [
     bg: '#2a0a0a',
     image: '/tony-adebanjo.jpg',
     available: true,
+    status: 'busy' as AvailabilityStatus,
     rating: 4.89,
     rate: 135,
     sessions: 98,
@@ -125,6 +132,7 @@ const mentors: Mentor[] = [
     bg: '#011f26',
     image: '/Image (Sarah Johnson).svg',
     available: false,
+    status: 'fully_booked' as AvailabilityStatus,
     rating: 4.96,
     rate: 170,
     sessions: 321,
@@ -135,6 +143,7 @@ const mentors: Mentor[] = [
 ];
 
 function MentorCard({ mentor }: { mentor: Mentor }) {
+  const status = mentor.status ?? (mentor.available ? 'available' : 'fully_booked');
   return (
     <div className="bg-white rounded-2xl border border-[rgba(20,18,16,0.07)] overflow-hidden flex flex-col transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_20px_48px_rgba(20,18,16,0.1)]">
       {/* Top */}
@@ -154,17 +163,15 @@ function MentorCard({ mentor }: { mentor: Mentor }) {
           ) : (
             <span>{mentor.initials}</span>
           )}
-          <span
-            className={`absolute bottom-[-2px] right-[-2px] w-3 h-3 rounded-full border-2 border-white ${
-              mentor.available ? 'bg-emerald-500' : 'bg-gray-300'
-            }`}
-          />
         </div>
 
         <div className="flex-1 min-w-0">
-          <p className="font-bold text-[#141210] text-[15px] truncate" style={{ fontFamily: "'Syne', sans-serif" }}>
-            {mentor.name}
-          </p>
+          <div className="flex items-center gap-2 mb-0.5">
+            <p className="font-bold text-[#141210] text-[15px] truncate" style={{ fontFamily: "'Syne', sans-serif" }}>
+              {mentor.name}
+            </p>
+            <AvailabilityBadge status={status} />
+          </div>
           <p className="text-[13px] text-[#94928d] truncate">{mentor.role}</p>
           <p className="text-[12px] font-medium mt-0.5" style={{ color: mentor.accent }}>
             {mentor.company}


### PR DESCRIPTION
 Description:
  
  ## Summary
  Adds a color-coded availability badge component for mentor profiles.
  
  ## Changes
  - New `AvailabilityBadge` component (`components/mentors/AvailabilityBadge.tsx`)
    - Three states: `available` (green), `busy` (amber), `fully_booked` (red)
    - Two variants: `badge` (pill with label) and `dot` (indicator only)
  - Updated `MentorDiscoveryLayout` to use the badge inline on each mentor card
  - Added `status` field to the `Mentor` type; falls back to boolean `available` for backward
  compatibility
  
  ## Acceptance Criteria
  - [x] Available — green badge
  - [x] Busy — amber badge
  - [x] Fully Booked — red badge

close #374 