### PR TITLE
Feat/saved mentors

### DIFF
--- a/app/dashboard/saved-mentors/page.tsx
+++ b/app/dashboard/saved-mentors/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import MentorCard from '@/components/mentors/MentorCard';
+import { mentors } from '@/lib/mentors';
+import type { Mentor } from '@/lib/mentors';
+
+export default function SavedMentorsPage() {
+  const [savedMentors, setSavedMentors] = useState<Mentor[]>([]);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem('bookmarkedMentors');
+    if (!stored) {
+      setSavedMentors([]);
+      return;
+    }
+
+    try {
+      const bookmarkedIds: number[] = JSON.parse(stored);
+      const saved = mentors.filter(mentor => bookmarkedIds.includes(mentor.id));
+      setSavedMentors(saved);
+    } catch (error) {
+      setSavedMentors([]);
+    }
+  }, []);
+
+  function handleBookmarkChange(nextIds: number[]) {
+    setSavedMentors(mentors.filter(mentor => nextIds.includes(mentor.id)));
+  }
+
+  return (
+    <div className="min-h-screen bg-[#f7f5f2]">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 border-b border-[rgba(20,18,16,0.07)]">
+        <p className="text-[11px] font-medium tracking-[0.15em] uppercase text-[#94928d] mb-2">
+          Your Dashboard
+        </p>
+        <h1
+          className="text-[clamp(28px,4vw,42px)] font-extrabold text-[#141210] leading-tight"
+          style={{ fontFamily: "'Syne', sans-serif" }}
+        >
+          Saved mentors
+        </h1>
+        <p className="mt-2 text-[15px] text-[#6b6860]">
+          Quickly revisit the mentors you bookmarked for future sessions.
+        </p>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {savedMentors.length === 0 ? (
+          <div className="rounded-3xl bg-white border border-[rgba(20,18,16,0.07)] p-12 text-center">
+            <p className="text-[15px] text-[#141210] font-semibold mb-3">No saved mentors yet</p>
+            <p className="text-[14px] text-[#6b6860]">
+              Bookmark mentors while browsing the directory to save them here.
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-5">
+            {savedMentors.map(mentor => (
+              <MentorCard key={mentor.id} mentor={mentor} onBookmarkChange={handleBookmarkChange} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/mentors/MentorCard.tsx
+++ b/components/mentors/MentorCard.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import type { Mentor } from '@/lib/mentors';
+
+interface MentorCardProps {
+  mentor: Mentor;
+  onBookmarkChange?: (nextIds: number[]) => void;
+}
+
+export default function MentorCard({ mentor, onBookmarkChange }: MentorCardProps) {
+  const [bookmarked, setBookmarked] = useState(false);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem('bookmarkedMentors');
+      const arr: number[] = raw ? JSON.parse(raw) : [];
+      setBookmarked(arr.includes(mentor.id));
+    } catch (e) {
+      setBookmarked(false);
+    }
+  }, [mentor.id]);
+
+  function toggleBookmark(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    try {
+      const raw = localStorage.getItem('bookmarkedMentors');
+      const arr: number[] = raw ? JSON.parse(raw) : [];
+      let next: number[];
+
+      if (arr.includes(mentor.id)) {
+        next = arr.filter(id => id !== mentor.id);
+        setBookmarked(false);
+      } else {
+        next = [...arr, mentor.id];
+        setBookmarked(true);
+      }
+
+      localStorage.setItem('bookmarkedMentors', JSON.stringify(next));
+      onBookmarkChange?.(next);
+    } catch (e) {
+      // ignore localStorage errors silently
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-2xl border border-[rgba(20,18,16,0.07)] overflow-hidden flex flex-col transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_20px_48px_rgba(20,18,16,0.1)]">
+      <div className="p-6 flex items-start gap-4">
+        <div
+          className="w-14 h-14 rounded-[14px] flex-shrink-0 flex items-center justify-center text-lg font-bold relative overflow-hidden"
+          style={{ background: mentor.bg, color: mentor.accent, fontFamily: "'Syne', sans-serif" }}
+        >
+          {mentor.image ? (
+            <Image
+              src={mentor.image}
+              alt={`${mentor.name} profile`}
+              width={56}
+              height={56}
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <span>{mentor.initials}</span>
+          )}
+          <span
+            className={`absolute bottom-[-2px] right-[-2px] w-3 h-3 rounded-full border-2 border-white ${
+              mentor.available ? 'bg-emerald-500' : 'bg-gray-300'
+            }`}
+          />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <p className="font-bold text-[#141210] text-[15px] truncate" style={{ fontFamily: "'Syne', sans-serif" }}>
+            {mentor.name}
+          </p>
+          <p className="text-[13px] text-[#94928d] truncate">{mentor.role}</p>
+          <p className="text-[12px] font-medium mt-0.5" style={{ color: mentor.accent }}>
+            {mentor.company}
+          </p>
+          <p className="text-[12px] mt-1 text-[#141210]">${mentor.rate}/hr</p>
+        </div>
+
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="flex items-center gap-1 bg-[#f7f5f2] rounded-lg px-2 py-1">
+            <span className="text-amber-400 text-[11px]">★</span>
+            <span className="text-[12px] font-semibold text-[#141210]">{mentor.rating}</span>
+          </div>
+
+          <button
+            onClick={toggleBookmark}
+            aria-pressed={bookmarked}
+            aria-label={bookmarked ? 'Remove bookmark' : 'Bookmark mentor'}
+            className={`w-9 h-9 rounded-lg flex items-center justify-center transition-colors border ${
+              bookmarked ? 'bg-amber-400 text-white border-amber-400' : 'bg-white text-[#6b6860] border-[rgba(20,18,16,0.08)]'
+            }`}
+          >
+            {bookmarked ? (
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M6 2C5.44772 2 5 2.44772 5 3V21L12 18L19 21V3C19 2.44772 18.5523 2 18 2H6Z" fill="currentColor" />
+              </svg>
+            ) : (
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M6 2C5.44772 2 5 2.44772 5 3V21L12 18L19 21V3C19 2.44772 18.5523 2 18 2H6Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            )}
+          </button>
+        </div>
+      </div>
+
+      <div className="h-px bg-[rgba(20,18,16,0.07)] mx-6" />
+
+      <div className="p-6 flex-1 flex flex-col gap-4">
+        <p className="text-[13.5px] leading-[1.7] text-[#6b6860] flex-1">{mentor.description}</p>
+        <div className="flex flex-wrap gap-1.5">
+          {mentor.tags.map(tag => (
+            <span
+              key={tag}
+              className="text-[11.5px] font-medium px-2.5 py-1 rounded-md bg-[#f7f5f2] text-[#6b6860] border border-[rgba(20,18,16,0.08)]"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="px-6 pb-6 flex items-center justify-between gap-3">
+        <span className="text-[12px] text-[#94928d]">
+          <strong className="text-[#141210] font-semibold">{mentor.sessions}</strong> sessions
+        </span>
+        <Link
+          href={mentor.available ? `/mentors/${mentor.id}` : '#'}
+          className={`text-[12.5px] font-semibold px-4 py-2 rounded-xl transition-all duration-200 ${
+            mentor.available
+              ? 'bg-[#141210] text-[#f7f5f2] hover:bg-[#2d2a27]'
+              : 'bg-[#f0efed] text-[#94928d] cursor-default pointer-events-none'
+          }`}
+          style={{ fontFamily: "'DM Sans', sans-serif" }}
+        >
+          {mentor.available ? 'Book session' : 'Fully booked'}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/mentors/MentorDiscoveryLayout.tsx
+++ b/components/mentors/MentorDiscoveryLayout.tsx
@@ -1,275 +1,22 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import Image from 'next/image';
-import Link from 'next/link';
+import { useState } from 'react';
+import MentorCard from '@/components/mentors/MentorCard';
+import { mentors } from '@/lib/mentors';
 
 const CATEGORIES = ['All', 'Engineering', 'Design', 'Product', 'Business', 'Data'];
 const AVAILABILITY = ['All', 'Available', 'Fully Booked'];
 
-type Mentor = {
-  id: number;
-  name: string;
-  role: string;
-  company: string;
-  category: string;
-  initials: string;
-  accent: string;
-  bg: string;
-  image?: string;
-  available: boolean;
-  rating: number;
-  rate: number;
-  sessions: number;
-  description: string;
-  tags: string[];
+type FilterPanelProps = {
+  activeCategory: string;
+  setActiveCategory: (v: string) => void;
+  activeAvailability: string;
+  setActiveAvailability: (v: string) => void;
+  minRate: string;
+  maxRate: string;
+  setMinRate: (v: string) => void;
+  setMaxRate: (v: string) => void;
 };
-
-const mentors: Mentor[] = [
-  {
-    id: 1,
-    name: 'Kwame Asante',
-    role: 'Staff Engineer',
-    company: 'Stripe',
-    category: 'Engineering',
-    initials: 'KA',
-    accent: '#3b82f6',
-    bg: '#0f1f3d',
-    image: '/tony-adebanjo.jpg',
-    available: true,
-    rating: 4.95,
-    rate: 180,
-    sessions: 204,
-    description:
-      'Helps engineers level up to Staff and beyond. Specialises in distributed systems, technical leadership, and promo packets.',
-    tags: ['System Design', 'Leadership', 'Go'],
-  },
-  {
-    id: 2,
-    name: 'Priya Menon',
-    role: 'Head of Product Design',
-    company: 'Figma',
-    category: 'Design',
-    initials: 'PM',
-    accent: '#a855f7',
-    bg: '#1e0f3d',
-    image: '/Image (Sarah Johnson).svg',
-    available: true,
-    rating: 4.98,
-    rate: 145,
-    sessions: 187,
-    description:
-      'Portfolio reviews, design system strategy, and breaking into senior IC or management tracks at top-tier product companies.',
-    tags: ['Figma', 'Design Systems', 'Portfolio'],
-  },
-  {
-    id: 3,
-    name: 'Tomás Reyes',
-    role: 'Senior PM',
-    company: 'Notion',
-    category: 'Product',
-    initials: 'TR',
-    accent: '#10b981',
-    bg: '#0a2318',
-    image: '/Image (Marcus Williams).svg',
-    available: false,
-    rating: 4.91,
-    rate: 160,
-    sessions: 139,
-    description:
-      'From APM to PM to Group PM — Tomás has made every jump and guides others through the same transitions with precision.',
-    tags: ['Roadmapping', 'Stakeholders', 'APM'],
-  },
-  {
-    id: 4,
-    name: 'Aisha Nwosu',
-    role: 'Data Science Lead',
-    company: 'Spotify',
-    category: 'Data',
-    initials: 'AN',
-    accent: '#f59e0b',
-    bg: '#2a1800',
-    image: '/Image (Cole Hathans).svg',
-    available: true,
-    rating: 4.93,
-    rate: 155,
-    sessions: 256,
-    description:
-      'ML pipelines, A/B testing at scale, and transitioning from academia to industry. Obsessed with making data teams actually functional.',
-    tags: ['Python', 'ML', 'Analytics'],
-  },
-  {
-    id: 5,
-    name: 'Leon Fischer',
-    role: 'Founding Engineer',
-    company: '3× YC Startups',
-    category: 'Engineering',
-    initials: 'LF',
-    accent: '#ef4444',
-    bg: '#2a0a0a',
-    image: '/tony-adebanjo.jpg',
-    available: true,
-    rating: 4.89,
-    rate: 135,
-    sessions: 98,
-    description:
-      'Zero to one builder. Helps early-career devs ship fast, make technical decisions under uncertainty, and navigate startup chaos.',
-    tags: ['React', 'Node', 'Startup'],
-  },
-  {
-    id: 6,
-    name: 'Sara Lindqvist',
-    role: 'VP of Growth',
-    company: 'Duolingo',
-    category: 'Business',
-    initials: 'SL',
-    accent: '#06b6d4',
-    bg: '#011f26',
-    image: '/Image (Sarah Johnson).svg',
-    available: false,
-    rating: 4.96,
-    rate: 170,
-    sessions: 321,
-    description:
-      'Growth loops, retention mechanics, and go-to-market for consumer apps. Former founder. Brutally practical and candid.',
-    tags: ['Growth', 'GTM', 'Retention'],
-  },
-];
-
-function MentorCard({ mentor }: { mentor: Mentor }) {
-  const [bookmarked, setBookmarked] = useState(false);
-
-  useEffect(() => {
-    try {
-      const raw = localStorage.getItem('bookmarkedMentors');
-      const arr = raw ? JSON.parse(raw) : [];
-      setBookmarked(arr.includes(mentor.id));
-    } catch (e) {
-      setBookmarked(false);
-    }
-  }, [mentor.id]);
-
-  function toggleBookmark(e: React.MouseEvent) {
-    e.preventDefault();
-    e.stopPropagation();
-    try {
-      const raw = localStorage.getItem('bookmarkedMentors');
-      const arr: number[] = raw ? JSON.parse(raw) : [];
-      let next: number[];
-      if (arr.includes(mentor.id)) {
-        next = arr.filter(id => id !== mentor.id);
-        setBookmarked(false);
-      } else {
-        next = [...arr, mentor.id];
-        setBookmarked(true);
-      }
-      localStorage.setItem('bookmarkedMentors', JSON.stringify(next));
-    } catch (e) {
-      // ignore localStorage errors silently
-    }
-  }
-
-  return (
-    <div className="bg-white rounded-2xl border border-[rgba(20,18,16,0.07)] overflow-hidden flex flex-col transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_20px_48px_rgba(20,18,16,0.1)]">
-      {/* Top */}
-      <div className="p-6 flex items-start gap-4">
-        <div
-          className="w-14 h-14 rounded-[14px] flex-shrink-0 flex items-center justify-center text-lg font-bold relative overflow-hidden"
-          style={{ background: mentor.bg, color: mentor.accent, fontFamily: "'Syne', sans-serif" }}
-        >
-          {mentor.image ? (
-            <Image
-              src={mentor.image}
-              alt={`${mentor.name} profile`}
-              width={56}
-              height={56}
-              className="w-full h-full object-cover"
-            />
-          ) : (
-            <span>{mentor.initials}</span>
-          )}
-          <span
-            className={`absolute bottom-[-2px] right-[-2px] w-3 h-3 rounded-full border-2 border-white ${
-              mentor.available ? 'bg-emerald-500' : 'bg-gray-300'
-            }`}
-          />
-        </div>
-
-        <div className="flex-1 min-w-0">
-          <p className="font-bold text-[#141210] text-[15px] truncate" style={{ fontFamily: "'Syne', sans-serif" }}>
-            {mentor.name}
-          </p>
-          <p className="text-[13px] text-[#94928d] truncate">{mentor.role}</p>
-          <p className="text-[12px] font-medium mt-0.5" style={{ color: mentor.accent }}>
-            {mentor.company}
-          </p>
-          <p className="text-[12px] mt-1 text-[#141210]">${mentor.rate}/hr</p>
-        </div>
-
-        <div className="flex items-center gap-2 flex-shrink-0">
-          <div className="flex items-center gap-1 bg-[#f7f5f2] rounded-lg px-2 py-1">
-            <span className="text-amber-400 text-[11px]">★</span>
-            <span className="text-[12px] font-semibold text-[#141210]">{mentor.rating}</span>
-          </div>
-
-          <button
-            onClick={toggleBookmark}
-            aria-pressed={bookmarked}
-            aria-label={bookmarked ? 'Remove bookmark' : 'Bookmark mentor'}
-            className={`w-9 h-9 rounded-lg flex items-center justify-center transition-colors border ${
-              bookmarked ? 'bg-amber-400 text-white border-amber-400' : 'bg-white text-[#6b6860] border-[rgba(20,18,16,0.08)]'
-            }`}
-          >
-            {bookmarked ? (
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M6 2C5.44772 2 5 2.44772 5 3V21L12 18L19 21V3C19 2.44772 18.5523 2 18 2H6Z" fill="currentColor" />
-              </svg>
-            ) : (
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M6 2C5.44772 2 5 2.44772 5 3V21L12 18L19 21V3C19 2.44772 18.5523 2 18 2H6Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-            )}
-          </button>
-        </div>
-      </div>
-
-      <div className="h-px bg-[rgba(20,18,16,0.07)] mx-6" />
-
-      {/* Body */}
-      <div className="p-6 flex-1 flex flex-col gap-4">
-        <p className="text-[13.5px] leading-[1.7] text-[#6b6860] flex-1">{mentor.description}</p>
-        <div className="flex flex-wrap gap-1.5">
-          {mentor.tags.map(tag => (
-            <span
-              key={tag}
-              className="text-[11.5px] font-medium px-2.5 py-1 rounded-md bg-[#f7f5f2] text-[#6b6860] border border-[rgba(20,18,16,0.08)]"
-            >
-              {tag}
-            </span>
-          ))}
-        </div>
-      </div>
-
-      {/* Footer */}
-      <div className="px-6 pb-6 flex items-center justify-between gap-3">
-        <span className="text-[12px] text-[#94928d]">
-          <strong className="text-[#141210] font-semibold">{mentor.sessions}</strong> sessions
-        </span>
-        <Link
-          href={mentor.available ? `/mentors/${mentor.id}` : '#'}
-          className={`text-[12.5px] font-semibold px-4 py-2 rounded-xl transition-all duration-200 ${
-            mentor.available
-              ? 'bg-[#141210] text-[#f7f5f2] hover:bg-[#2d2a27]'
-              : 'bg-[#f0efed] text-[#94928d] cursor-default pointer-events-none'
-          }`}
-          style={{ fontFamily: "'DM Sans', sans-serif" }}
-        >
-          {mentor.available ? 'Book session' : 'Fully booked'}
-        </Link>
-      </div>
-    </div>
-  );
-}
 
 function FilterPanel({
   activeCategory,
@@ -280,16 +27,7 @@ function FilterPanel({
   maxRate,
   setMinRate,
   setMaxRate,
-}: {
-  activeCategory: string;
-  setActiveCategory: (v: string) => void;
-  activeAvailability: string;
-  setActiveAvailability: (v: string) => void;
-  minRate: string;
-  maxRate: string;
-  setMinRate: (v: string) => void;
-  setMaxRate: (v: string) => void;
-}) {
+}: FilterPanelProps) {
   return (
     <>
       {/* Category */}

--- a/components/mentors/MentorDiscoveryLayout.tsx
+++ b/components/mentors/MentorDiscoveryLayout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -137,6 +137,38 @@ const mentors: Mentor[] = [
 ];
 
 function MentorCard({ mentor }: { mentor: Mentor }) {
+  const [bookmarked, setBookmarked] = useState(false);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem('bookmarkedMentors');
+      const arr = raw ? JSON.parse(raw) : [];
+      setBookmarked(arr.includes(mentor.id));
+    } catch (e) {
+      setBookmarked(false);
+    }
+  }, [mentor.id]);
+
+  function toggleBookmark(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      const raw = localStorage.getItem('bookmarkedMentors');
+      const arr: number[] = raw ? JSON.parse(raw) : [];
+      let next: number[];
+      if (arr.includes(mentor.id)) {
+        next = arr.filter(id => id !== mentor.id);
+        setBookmarked(false);
+      } else {
+        next = [...arr, mentor.id];
+        setBookmarked(true);
+      }
+      localStorage.setItem('bookmarkedMentors', JSON.stringify(next));
+    } catch (e) {
+      // ignore localStorage errors silently
+    }
+  }
+
   return (
     <div className="bg-white rounded-2xl border border-[rgba(20,18,16,0.07)] overflow-hidden flex flex-col transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_20px_48px_rgba(20,18,16,0.1)]">
       {/* Top */}
@@ -174,9 +206,30 @@ function MentorCard({ mentor }: { mentor: Mentor }) {
           <p className="text-[12px] mt-1 text-[#141210]">${mentor.rate}/hr</p>
         </div>
 
-        <div className="flex items-center gap-1 bg-[#f7f5f2] rounded-lg px-2 py-1 flex-shrink-0">
-          <span className="text-amber-400 text-[11px]">★</span>
-          <span className="text-[12px] font-semibold text-[#141210]">{mentor.rating}</span>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="flex items-center gap-1 bg-[#f7f5f2] rounded-lg px-2 py-1">
+            <span className="text-amber-400 text-[11px]">★</span>
+            <span className="text-[12px] font-semibold text-[#141210]">{mentor.rating}</span>
+          </div>
+
+          <button
+            onClick={toggleBookmark}
+            aria-pressed={bookmarked}
+            aria-label={bookmarked ? 'Remove bookmark' : 'Bookmark mentor'}
+            className={`w-9 h-9 rounded-lg flex items-center justify-center transition-colors border ${
+              bookmarked ? 'bg-amber-400 text-white border-amber-400' : 'bg-white text-[#6b6860] border-[rgba(20,18,16,0.08)]'
+            }`}
+          >
+            {bookmarked ? (
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M6 2C5.44772 2 5 2.44772 5 3V21L12 18L19 21V3C19 2.44772 18.5523 2 18 2H6Z" fill="currentColor" />
+              </svg>
+            ) : (
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M6 2C5.44772 2 5 2.44772 5 3V21L12 18L19 21V3C19 2.44772 18.5523 2 18 2H6Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            )}
+          </button>
         </div>
       </div>
 

--- a/lib/mentors.ts
+++ b/lib/mentors.ts
@@ -1,0 +1,130 @@
+'use client';
+
+export type Mentor = {
+  id: number;
+  name: string;
+  role: string;
+  company: string;
+  category: string;
+  initials: string;
+  accent: string;
+  bg: string;
+  image?: string;
+  available: boolean;
+  rating: number;
+  rate: number;
+  sessions: number;
+  description: string;
+  tags: string[];
+};
+
+export const mentors: Mentor[] = [
+  {
+    id: 1,
+    name: 'Kwame Asante',
+    role: 'Staff Engineer',
+    company: 'Stripe',
+    category: 'Engineering',
+    initials: 'KA',
+    accent: '#3b82f6',
+    bg: '#0f1f3d',
+    image: '/tony-adebanjo.jpg',
+    available: true,
+    rating: 4.95,
+    rate: 180,
+    sessions: 204,
+    description:
+      'Helps engineers level up to Staff and beyond. Specialises in distributed systems, technical leadership, and promo packets.',
+    tags: ['System Design', 'Leadership', 'Go'],
+  },
+  {
+    id: 2,
+    name: 'Priya Menon',
+    role: 'Head of Product Design',
+    company: 'Figma',
+    category: 'Design',
+    initials: 'PM',
+    accent: '#a855f7',
+    bg: '#1e0f3d',
+    image: '/Image (Sarah Johnson).svg',
+    available: true,
+    rating: 4.98,
+    rate: 145,
+    sessions: 187,
+    description:
+      'Portfolio reviews, design system strategy, and breaking into senior IC or management tracks at top-tier product companies.',
+    tags: ['Figma', 'Design Systems', 'Portfolio'],
+  },
+  {
+    id: 3,
+    name: 'Tomás Reyes',
+    role: 'Senior PM',
+    company: 'Notion',
+    category: 'Product',
+    initials: 'TR',
+    accent: '#10b981',
+    bg: '#0a2318',
+    image: '/Image (Marcus Williams).svg',
+    available: false,
+    rating: 4.91,
+    rate: 160,
+    sessions: 139,
+    description:
+      'From APM to PM to Group PM — Tomás has made every jump and guides others through the same transitions with precision.',
+    tags: ['Roadmapping', 'Stakeholders', 'APM'],
+  },
+  {
+    id: 4,
+    name: 'Aisha Nwosu',
+    role: 'Data Science Lead',
+    company: 'Spotify',
+    category: 'Data',
+    initials: 'AN',
+    accent: '#f59e0b',
+    bg: '#2a1800',
+    image: '/Image (Cole Hathans).svg',
+    available: true,
+    rating: 4.93,
+    rate: 155,
+    sessions: 256,
+    description:
+      'ML pipelines, A/B testing at scale, and transitioning from academia to industry. Obsessed with making data teams actually functional.',
+    tags: ['Python', 'ML', 'Analytics'],
+  },
+  {
+    id: 5,
+    name: 'Leon Fischer',
+    role: 'Founding Engineer',
+    company: '3× YC Startups',
+    category: 'Engineering',
+    initials: 'LF',
+    accent: '#ef4444',
+    bg: '#2a0a0a',
+    image: '/tony-adebanjo.jpg',
+    available: true,
+    rating: 4.89,
+    rate: 135,
+    sessions: 98,
+    description:
+      'Zero to one builder. Helps early-career devs ship fast, make technical decisions under uncertainty, and navigate startup chaos.',
+    tags: ['React', 'Node', 'Startup'],
+  },
+  {
+    id: 6,
+    name: 'Sara Lindqvist',
+    role: 'VP of Growth',
+    company: 'Duolingo',
+    category: 'Business',
+    initials: 'SL',
+    accent: '#06b6d4',
+    bg: '#011f26',
+    image: '/Image (Sarah Johnson).svg',
+    available: false,
+    rating: 4.96,
+    rate: 170,
+    sessions: 321,
+    description:
+      'Growth loops, retention mechanics, and go-to-market for consumer apps. Former founder. Brutally practical and candid.',
+    tags: ['Growth', 'GTM', 'Retention'],
+  },
+];


### PR DESCRIPTION
✅ Implemented new route: [page.tsx](https://didactic-space-meme-g9ppr4xj6rq2vv9r.github.dev/)

What it does
Reads bookmarked mentor IDs from [localStorage](https://didactic-space-meme-g9ppr4xj6rq2vv9r.github.dev/) key bookmarkedMentors
Displays matching mentors using shared mentor data
Shows an empty state if no mentors are bookmarked
Supports removing bookmarks from the saved list via [MentorCard](https://didactic-space-meme-g9ppr4xj6rq2vv9r.github.dev/)

closes #387 