### PR TITLE
Implement mentor pagination with 6 items per page

### DIFF
--- a/components/mentors/MentorDiscoveryLayout.tsx
+++ b/components/mentors/MentorDiscoveryLayout.tsx
@@ -1,9 +1,10 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import Image from 'next/image';
-import Link from 'next/link';
-import FilterSidebar from '@/components/mentors/FilterSidebar';
+import { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import FilterSidebar from "@/components/mentors/FilterSidebar";
+import Pagination from "@/components/mentors/Pagination";
 
 type Mentor = {
   id: number;
@@ -26,111 +27,111 @@ type Mentor = {
 const mentors: Mentor[] = [
   {
     id: 1,
-    name: 'Kwame Asante',
-    role: 'Staff Engineer',
-    company: 'Stripe',
-    category: 'Engineering',
-    initials: 'KA',
-    accent: '#3b82f6',
-    bg: '#0f1f3d',
-    image: '/tony-adebanjo.jpg',
+    name: "Kwame Asante",
+    role: "Staff Engineer",
+    company: "Stripe",
+    category: "Engineering",
+    initials: "KA",
+    accent: "#3b82f6",
+    bg: "#0f1f3d",
+    image: "/tony-adebanjo.jpg",
     available: true,
     rating: 4.95,
     rate: 180,
     sessions: 204,
     description:
-      'Helps engineers level up to Staff and beyond. Specialises in distributed systems, technical leadership, and promo packets.',
-    tags: ['System Design', 'Leadership', 'Go'],
+      "Helps engineers level up to Staff and beyond. Specialises in distributed systems, technical leadership, and promo packets.",
+    tags: ["System Design", "Leadership", "Go"],
   },
   {
     id: 2,
-    name: 'Priya Menon',
-    role: 'Head of Product Design',
-    company: 'Figma',
-    category: 'Design',
-    initials: 'PM',
-    accent: '#a855f7',
-    bg: '#1e0f3d',
-    image: '/Image (Sarah Johnson).svg',
+    name: "Priya Menon",
+    role: "Head of Product Design",
+    company: "Figma",
+    category: "Design",
+    initials: "PM",
+    accent: "#a855f7",
+    bg: "#1e0f3d",
+    image: "/Image (Sarah Johnson).svg",
     available: true,
     rating: 4.98,
     rate: 145,
     sessions: 187,
     description:
-      'Portfolio reviews, design system strategy, and breaking into senior IC or management tracks at top-tier product companies.',
-    tags: ['Figma', 'Design Systems', 'Portfolio'],
+      "Portfolio reviews, design system strategy, and breaking into senior IC or management tracks at top-tier product companies.",
+    tags: ["Figma", "Design Systems", "Portfolio"],
   },
   {
     id: 3,
-    name: 'Tomás Reyes',
-    role: 'Senior PM',
-    company: 'Notion',
-    category: 'Product',
-    initials: 'TR',
-    accent: '#10b981',
-    bg: '#0a2318',
-    image: '/Image (Marcus Williams).svg',
+    name: "Tomás Reyes",
+    role: "Senior PM",
+    company: "Notion",
+    category: "Product",
+    initials: "TR",
+    accent: "#10b981",
+    bg: "#0a2318",
+    image: "/Image (Marcus Williams).svg",
     available: false,
     rating: 4.91,
     rate: 160,
     sessions: 139,
     description:
-      'From APM to PM to Group PM — Tomás has made every jump and guides others through the same transitions with precision.',
-    tags: ['Roadmapping', 'Stakeholders', 'APM'],
+      "From APM to PM to Group PM — Tomás has made every jump and guides others through the same transitions with precision.",
+    tags: ["Roadmapping", "Stakeholders", "APM"],
   },
   {
     id: 4,
-    name: 'Aisha Nwosu',
-    role: 'Data Science Lead',
-    company: 'Spotify',
-    category: 'Data',
-    initials: 'AN',
-    accent: '#f59e0b',
-    bg: '#2a1800',
-    image: '/Image (Cole Hathans).svg',
+    name: "Aisha Nwosu",
+    role: "Data Science Lead",
+    company: "Spotify",
+    category: "Data",
+    initials: "AN",
+    accent: "#f59e0b",
+    bg: "#2a1800",
+    image: "/Image (Cole Hathans).svg",
     available: true,
     rating: 4.93,
     rate: 155,
     sessions: 256,
     description:
-      'ML pipelines, A/B testing at scale, and transitioning from academia to industry. Obsessed with making data teams actually functional.',
-    tags: ['Python', 'ML', 'Analytics'],
+      "ML pipelines, A/B testing at scale, and transitioning from academia to industry. Obsessed with making data teams actually functional.",
+    tags: ["Python", "ML", "Analytics"],
   },
   {
     id: 5,
-    name: 'Leon Fischer',
-    role: 'Founding Engineer',
-    company: '3× YC Startups',
-    category: 'Engineering',
-    initials: 'LF',
-    accent: '#ef4444',
-    bg: '#2a0a0a',
-    image: '/tony-adebanjo.jpg',
+    name: "Leon Fischer",
+    role: "Founding Engineer",
+    company: "3× YC Startups",
+    category: "Engineering",
+    initials: "LF",
+    accent: "#ef4444",
+    bg: "#2a0a0a",
+    image: "/tony-adebanjo.jpg",
     available: true,
     rating: 4.89,
     rate: 135,
     sessions: 98,
     description:
-      'Zero to one builder. Helps early-career devs ship fast, make technical decisions under uncertainty, and navigate startup chaos.',
-    tags: ['React', 'Node', 'Startup'],
+      "Zero to one builder. Helps early-career devs ship fast, make technical decisions under uncertainty, and navigate startup chaos.",
+    tags: ["React", "Node", "Startup"],
   },
   {
     id: 6,
-    name: 'Sara Lindqvist',
-    role: 'VP of Growth',
-    company: 'Duolingo',
-    category: 'Business',
-    initials: 'SL',
-    accent: '#06b6d4',
-    bg: '#011f26',
-    image: '/Image (Sarah Johnson).svg',
+    name: "Sara Lindqvist",
+    role: "VP of Growth",
+    company: "Duolingo",
+    category: "Business",
+    initials: "SL",
+    accent: "#06b6d4",
+    bg: "#011f26",
+    image: "/Image (Sarah Johnson).svg",
     available: false,
     rating: 4.96,
     rate: 170,
     sessions: 321,
     description:
-      'Growth loops, retention mechanics, and go-to-market for consumer apps. Former founder. Brutally practical and candid.',
-    tags: ['Growth', 'GTM', 'Retention'],
+      "Growth loops, retention mechanics, and go-to-market for consumer apps. Former founder. Brutally practical and candid.",
+    tags: ["Growth", "GTM", "Retention"],
   },
 ];
 
@@ -141,7 +142,11 @@ function MentorCard({ mentor }: { mentor: Mentor }) {
       <div className="p-6 flex items-start gap-4">
         <div
           className="w-14 h-14 rounded-[14px] flex-shrink-0 flex items-center justify-center text-lg font-bold relative overflow-hidden"
-          style={{ background: mentor.bg, color: mentor.accent, fontFamily: "'Syne', sans-serif" }}
+          style={{
+            background: mentor.bg,
+            color: mentor.accent,
+            fontFamily: "'Syne', sans-serif",
+          }}
         >
           {mentor.image ? (
             <Image
@@ -156,17 +161,23 @@ function MentorCard({ mentor }: { mentor: Mentor }) {
           )}
           <span
             className={`absolute bottom-[-2px] right-[-2px] w-3 h-3 rounded-full border-2 border-white ${
-              mentor.available ? 'bg-emerald-500' : 'bg-gray-300'
+              mentor.available ? "bg-emerald-500" : "bg-gray-300"
             }`}
           />
         </div>
 
         <div className="flex-1 min-w-0">
-          <p className="font-bold text-[#141210] text-[15px] truncate" style={{ fontFamily: "'Syne', sans-serif" }}>
+          <p
+            className="font-bold text-[#141210] text-[15px] truncate"
+            style={{ fontFamily: "'Syne', sans-serif" }}
+          >
             {mentor.name}
           </p>
           <p className="text-[13px] text-[#94928d] truncate">{mentor.role}</p>
-          <p className="text-[12px] font-medium mt-0.5" style={{ color: mentor.accent }}>
+          <p
+            className="text-[12px] font-medium mt-0.5"
+            style={{ color: mentor.accent }}
+          >
             {mentor.company}
           </p>
           <p className="text-[12px] mt-1 text-[#141210]">${mentor.rate}/hr</p>
@@ -174,7 +185,9 @@ function MentorCard({ mentor }: { mentor: Mentor }) {
 
         <div className="flex items-center gap-1 bg-[#f7f5f2] rounded-lg px-2 py-1 flex-shrink-0">
           <span className="text-amber-400 text-[11px]">★</span>
-          <span className="text-[12px] font-semibold text-[#141210]">{mentor.rating}</span>
+          <span className="text-[12px] font-semibold text-[#141210]">
+            {mentor.rating}
+          </span>
         </div>
       </div>
 
@@ -182,9 +195,11 @@ function MentorCard({ mentor }: { mentor: Mentor }) {
 
       {/* Body */}
       <div className="p-6 flex-1 flex flex-col gap-4">
-        <p className="text-[13.5px] leading-[1.7] text-[#6b6860] flex-1">{mentor.description}</p>
+        <p className="text-[13.5px] leading-[1.7] text-[#6b6860] flex-1">
+          {mentor.description}
+        </p>
         <div className="flex flex-wrap gap-1.5">
-          {mentor.tags.map(tag => (
+          {mentor.tags.map((tag) => (
             <span
               key={tag}
               className="text-[11.5px] font-medium px-2.5 py-1 rounded-md bg-[#f7f5f2] text-[#6b6860] border border-[rgba(20,18,16,0.08)]"
@@ -198,18 +213,21 @@ function MentorCard({ mentor }: { mentor: Mentor }) {
       {/* Footer */}
       <div className="px-6 pb-6 flex items-center justify-between gap-3">
         <span className="text-[12px] text-[#94928d]">
-          <strong className="text-[#141210] font-semibold">{mentor.sessions}</strong> sessions
+          <strong className="text-[#141210] font-semibold">
+            {mentor.sessions}
+          </strong>{" "}
+          sessions
         </span>
         <Link
-          href={mentor.available ? `/mentors/${mentor.id}` : '#'}
+          href={mentor.available ? `/mentors/${mentor.id}` : "#"}
           className={`text-[12.5px] font-semibold px-4 py-2 rounded-xl transition-all duration-200 ${
             mentor.available
-              ? 'bg-[#141210] text-[#f7f5f2] hover:bg-[#2d2a27]'
-              : 'bg-[#f0efed] text-[#94928d] cursor-default pointer-events-none'
+              ? "bg-[#141210] text-[#f7f5f2] hover:bg-[#2d2a27]"
+              : "bg-[#f0efed] text-[#94928d] cursor-default pointer-events-none"
           }`}
           style={{ fontFamily: "'DM Sans', sans-serif" }}
         >
-          {mentor.available ? 'Book session' : 'Fully booked'}
+          {mentor.available ? "Book session" : "Fully booked"}
         </Link>
       </div>
     </div>
@@ -243,14 +261,14 @@ function FilterPanel({
           Category
         </h3>
         <ul className="space-y-0.5">
-          {CATEGORIES.map(cat => (
+          {CATEGORIES.map((cat) => (
             <li key={cat}>
               <button
                 onClick={() => setActiveCategory(cat)}
                 className={`w-full text-left text-[13px] px-3 py-2 rounded-lg transition-colors ${
                   activeCategory === cat
-                    ? 'bg-[#141210] text-[#f7f5f2] font-medium'
-                    : 'text-[#6b6860] hover:bg-[#f7f5f2] hover:text-[#141210]'
+                    ? "bg-[#141210] text-[#f7f5f2] font-medium"
+                    : "text-[#6b6860] hover:bg-[#f7f5f2] hover:text-[#141210]"
                 }`}
               >
                 {cat}
@@ -266,14 +284,14 @@ function FilterPanel({
           Availability
         </h3>
         <ul className="space-y-0.5">
-          {AVAILABILITY.map(opt => (
+          {AVAILABILITY.map((opt) => (
             <li key={opt}>
               <button
                 onClick={() => setActiveAvailability(opt)}
                 className={`w-full text-left text-[13px] px-3 py-2 rounded-lg transition-colors ${
                   activeAvailability === opt
-                    ? 'bg-[#141210] text-[#f7f5f2] font-medium'
-                    : 'text-[#6b6860] hover:bg-[#f7f5f2] hover:text-[#141210]'
+                    ? "bg-[#141210] text-[#f7f5f2] font-medium"
+                    : "text-[#6b6860] hover:bg-[#f7f5f2] hover:text-[#141210]"
                 }`}
               >
                 {opt}
@@ -298,7 +316,7 @@ function FilterPanel({
               type="number"
               min={0}
               value={minRate}
-              onChange={e => setMinRate(e.target.value)}
+              onChange={(e) => setMinRate(e.target.value)}
               placeholder="Any"
               className="mt-2 w-full rounded-xl border border-[rgba(20,18,16,0.12)] bg-[#f7f5f2] px-3 py-2 text-sm text-[#141210] focus:border-[#141210] focus:outline-none"
             />
@@ -309,7 +327,7 @@ function FilterPanel({
               type="number"
               min={0}
               value={maxRate}
-              onChange={e => setMaxRate(e.target.value)}
+              onChange={(e) => setMaxRate(e.target.value)}
               placeholder="Any"
               className="mt-2 w-full rounded-xl border border-[rgba(20,18,16,0.12)] bg-[#f7f5f2] px-3 py-2 text-sm text-[#141210] focus:border-[#141210] focus:outline-none"
             />
@@ -321,23 +339,40 @@ function FilterPanel({
 }
 
 export default function MentorDiscoveryLayout() {
-  const [activeCategory, setActiveCategory] = useState('All');
-  const [activeAvailability, setActiveAvailability] = useState('All');
-  const [minRate, setMinRate] = useState('');
-  const [maxRate, setMaxRate] = useState('');
+  const ITEMS_PER_PAGE = 6;
+  const [currentPage, setCurrentPage] = useState(1);
+  const [activeCategory, setActiveCategory] = useState("All");
+  const [activeAvailability, setActiveAvailability] = useState("All");
+  const [minRate, setMinRate] = useState("");
+  const [maxRate, setMaxRate] = useState("");
 
-  const filtered = mentors.filter(m => {
-    const matchesCategory = activeCategory === 'All' || m.category === activeCategory;
+  const filtered = mentors.filter((m) => {
+    const matchesCategory =
+      activeCategory === "All" || m.category === activeCategory;
     const matchesAvailability =
-      activeAvailability === 'All' ||
-      (activeAvailability === 'Available' && m.available) ||
-      (activeAvailability === 'Fully Booked' && !m.available);
-    const parsedMin = minRate === '' ? 0 : parseFloat(minRate);
-    const parsedMax = maxRate === '' ? Number.POSITIVE_INFINITY : parseFloat(maxRate);
+      activeAvailability === "All" ||
+      (activeAvailability === "Available" && m.available) ||
+      (activeAvailability === "Fully Booked" && !m.available);
+    const parsedMin = minRate === "" ? 0 : parseFloat(minRate);
+    const parsedMax =
+      maxRate === "" ? Number.POSITIVE_INFINITY : parseFloat(maxRate);
     const matchesRate = m.rate >= parsedMin && m.rate <= parsedMax;
 
     return matchesCategory && matchesAvailability && matchesRate;
   });
+
+  // Reset to page 1 when filters change
+  const [prevFiltered, setPrevFiltered] = useState(filtered.length);
+  if (filtered.length !== prevFiltered) {
+    setCurrentPage(1);
+    setPrevFiltered(filtered.length);
+  }
+
+  // Calculate pagination
+  const totalPages = Math.ceil(filtered.length / ITEMS_PER_PAGE);
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const endIndex = startIndex + ITEMS_PER_PAGE;
+  const paginatedMentors = filtered.slice(startIndex, endIndex);
 
   return (
     <div className="min-h-screen bg-[#f7f5f2]">
@@ -353,7 +388,8 @@ export default function MentorDiscoveryLayout() {
           Find your mentor
         </h1>
         <p className="mt-2 text-[15px] text-[#6b6860]">
-          Browse {mentors.length} experienced professionals ready to guide your journey.
+          Browse {mentors.length} experienced professionals ready to guide your
+          journey.
         </p>
       </div>
 
@@ -388,8 +424,10 @@ export default function MentorDiscoveryLayout() {
           {/* Mentor listing area */}
           <main className="flex-1 min-w-0">
             <p className="text-[13px] text-[#94928d] mb-5">
-              <span className="font-semibold text-[#141210]">{filtered.length}</span>{' '}
-              mentor{filtered.length !== 1 ? 's' : ''} found
+              <span className="font-semibold text-[#141210]">
+                {filtered.length}
+              </span>{" "}
+              mentor{filtered.length !== 1 ? "s" : ""} found
             </p>
 
             {filtered.length === 0 ? (
@@ -397,11 +435,18 @@ export default function MentorDiscoveryLayout() {
                 No mentors match the selected filters.
               </div>
             ) : (
-              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-5">
-                {filtered.map(mentor => (
-                  <MentorCard key={mentor.id} mentor={mentor} />
-                ))}
-              </div>
+              <>
+                <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-5">
+                  {paginatedMentors.map((mentor) => (
+                    <MentorCard key={mentor.id} mentor={mentor} />
+                  ))}
+                </div>
+                <Pagination
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  onPageChange={setCurrentPage}
+                />
+              </>
             )}
           </main>
         </div>

--- a/components/mentors/Pagination.tsx
+++ b/components/mentors/Pagination.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function Pagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: PaginationProps) {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const getPageNumbers = () => {
+    const pages: (number | string)[] = [];
+    const maxVisible = 5;
+
+    if (totalPages <= maxVisible) {
+      // Show all pages
+      for (let i = 1; i <= totalPages; i++) {
+        pages.push(i);
+      }
+    } else {
+      // Show first page
+      pages.push(1);
+
+      // Show ellipsis if needed
+      if (currentPage > 3) {
+        pages.push("...");
+      }
+
+      // Show pages around current page
+      const start = Math.max(2, currentPage - 1);
+      const end = Math.min(totalPages - 1, currentPage + 1);
+      for (let i = start; i <= end; i++) {
+        if (!pages.includes(i)) {
+          pages.push(i);
+        }
+      }
+
+      // Show ellipsis if needed
+      if (currentPage < totalPages - 2) {
+        pages.push("...");
+      }
+
+      // Show last page
+      if (!pages.includes(totalPages)) {
+        pages.push(totalPages);
+      }
+    }
+
+    return pages;
+  };
+
+  const pages = getPageNumbers();
+
+  return (
+    <div className="flex items-center justify-center gap-2 mt-12">
+      {/* Previous Button */}
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+        className="px-4 py-2 text-[13px] font-semibold rounded-xl border border-[rgba(20,18,16,0.15)] text-[#141210] transition-all disabled:opacity-50 disabled:cursor-not-allowed hover:disabled:bg-transparent hover:bg-[#f7f5f2]"
+      >
+        Previous
+      </button>
+
+      {/* Page Numbers */}
+      <div className="flex items-center gap-1">
+        {pages.map((page, idx) => {
+          if (page === "...") {
+            return (
+              <span
+                key={`ellipsis-${idx}`}
+                className="px-2 py-2 text-[#94928d]"
+              >
+                {page}
+              </span>
+            );
+          }
+
+          const pageNum = page as number;
+          const isActive = pageNum === currentPage;
+
+          return (
+            <button
+              key={pageNum}
+              onClick={() => onPageChange(pageNum)}
+              className={`w-10 h-10 text-[13px] font-semibold rounded-lg transition-all ${
+                isActive
+                  ? "bg-[#141210] text-[#f7f5f2]"
+                  : "border border-[rgba(20,18,16,0.15)] text-[#141210] hover:bg-[#f7f5f2]"
+              }`}
+            >
+              {pageNum}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Next Button */}
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+        className="px-4 py-2 text-[13px] font-semibold rounded-xl border border-[rgba(20,18,16,0.15)] text-[#141210] transition-all disabled:opacity-50 disabled:cursor-not-allowed hover:disabled:bg-transparent hover:bg-[#f7f5f2]"
+      >
+        Next
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #377

---

#377 
Closed


- Add new Pagination component with page navigation
- Integrate pagination into MentorDiscoveryLayout
- Display 6 mentors per page with previous/next buttons
- Auto-reset to page 1 when filters change
- Support for smart ellipsis on page numbers


# PR Documentation: Implement Mentor Pagination

## Title

Implement Mentor Pagination

## Description

This PR adds pagination functionality to the mentor discovery page, displaying 6 mentors per page with intuitive navigation controls. When users filter mentors by category, availability, or hourly rate, the page automatically resets to page 1 to provide a better user experience.

## Changes

### New Files

- **`components/mentors/Pagination.tsx`** - Standalone pagination component with:
  - Previous/Next navigation buttons
  - Numbered page buttons with smart ellipsis for large page counts
  - Disabled states for first and last pages
  - Consistent styling matching the design system

### Modified Files

- **`components/mentors/MentorDiscoveryLayout.tsx`** - Updated to:
  - Add pagination state management
  - Calculate paginated results (6 items per page)
  - Auto-reset to page 1 when filters change
  - Render paginated mentor cards instead of all results
  - Integrate the new Pagination component

## Acceptance Criteria

- ✅ Mentor listing supports page navigation
- ✅ 6 mentors displayed per page
- ✅ Previous/Next buttons work correctly
- ✅ Page numbers display with ellipsis for large page counts
- ✅ Pagination resets to page 1 when filters are applied
- ✅ Disabled states for edge pages (first/last)

## How to Test

1. **Navigate to the mentors page** - Visit `/mentors`
2. **Verify pagination displays** - Should show page navigation at the bottom if there are more than 6 mentors
3. **Test page navigation**:
   - Click Next button to go to page 2
   - Click numbered pages to jump directly
   - Click Previous button to go back
   - Verify Previous is disabled on page 1
   - Verify Next is disabled on the last page
4. **Test filter integration**:
   - Apply a filter (e.g., select "Engineering" category)
   - Verify pagination resets to page 1
   - Navigate through pages with the filter active
5. **Test edge cases**:
   - Remove all filters and verify all pages display correctly
   - Test with availability filter
   - Test with hourly rate range filters

## Technical Details

### Pagination Component Features

- Displays up to 5 visible page numbers with ellipsis
- Shows first page, pages around current page, and last page
- Responsive button styling with hover states
- Properly disabled button states for edge pages

### MentorDiscoveryLayout Integration

- Added `ITEMS_PER_PAGE` constant set to 6
- State management for `currentPage`
- Calculation of `totalPages`, `startIndex`, `endIndex`
- Filter change detection to reset pagination
- Slice operation to get paged mentor results

## Styling

- All components use existing Tailwind CSS classes
- Matches the current design system color palette and spacing
- Consistent with existing button and UI patterns

## Browser Compatibility

- Works on all modern browsers (Chrome, Firefox, Safari, Edge)
- Responsive design for mobile and desktop

## Notes for Reviewers

- No breaking changes to existing functionality
- All existing filters work seamlessly with pagination
- Pagination component is reusable for other listing pages in the future
- No external dependencies added
