### PR TITLE
Feat/connect

### DIFF
--- a/app/api/mentors/route.ts
+++ b/app/api/mentors/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { mentors } from '@/lib/mentors';
+
+function parseCategory(value: string | null) {
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  return mentors.find(m => m.category.toLowerCase() === normalized) ? value : null;
+}
+
+function parseAvailability(value: string | null) {
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'available') return 'Available';
+  if (normalized === 'fully-booked' || normalized === 'fullybooked' || normalized === 'fully booked') return 'Fully Booked';
+  return null;
+}
+
+function parseRate(value: string | null) {
+  if (!value) return null;
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+export function GET(request: Request) {
+  const url = new URL(request.url);
+  const expertise = url.searchParams.get('expertise');
+  const availability = url.searchParams.get('availability');
+  const minRate = parseRate(url.searchParams.get('minRate'));
+  const maxRate = parseRate(url.searchParams.get('maxRate'));
+
+  let results = mentors;
+
+  const category = parseCategory(expertise);
+  if (category) {
+    results = results.filter(mentor => mentor.category.toLowerCase() === category.trim().toLowerCase());
+  }
+
+  const availabilityFilter = parseAvailability(availability);
+  if (availabilityFilter === 'Available') {
+    results = results.filter(mentor => mentor.available);
+  } else if (availabilityFilter === 'Fully Booked') {
+    results = results.filter(mentor => !mentor.available);
+  }
+
+  if (minRate !== null) {
+    results = results.filter(mentor => mentor.rate >= minRate);
+  }
+
+  if (maxRate !== null) {
+    results = results.filter(mentor => mentor.rate <= maxRate);
+  }
+
+  return NextResponse.json(results);
+}

--- a/components/mentors/MentorDiscoveryLayout.tsx
+++ b/components/mentors/MentorDiscoveryLayout.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import MentorCard from '@/components/mentors/MentorCard';
-import { mentors } from '@/lib/mentors';
+import { MentorCardSkeleton } from '@/components/loadingSkeletons';
+import type { Mentor } from '@/lib/mentors';
 
 const CATEGORIES = ['All', 'Engineering', 'Design', 'Product', 'Business', 'Data'];
 const AVAILABILITY = ['All', 'Available', 'Fully Booked'];
@@ -151,10 +152,40 @@ export default function MentorDiscoveryLayout() {
   const initialMinRate = useMemo(() => normalizeRateParam(searchParams.get('minRate')), [searchParams]);
   const initialMaxRate = useMemo(() => normalizeRateParam(searchParams.get('maxRate')), [searchParams]);
 
+  const [mentorList, setMentorList] = useState<Mentor[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [activeCategory, setActiveCategory] = useState(initialCategory);
   const [activeAvailability, setActiveAvailability] = useState(initialAvailability);
   const [minRate, setMinRate] = useState(initialMinRate);
   const [maxRate, setMaxRate] = useState(initialMaxRate);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const fetchMentors = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch('/api/mentors', { signal: controller.signal });
+        if (!response.ok) {
+          throw new Error('Failed to load mentors');
+        }
+
+        const data = (await response.json()) as Mentor[];
+        setMentorList(data);
+      } catch (err) {
+        if ((err as any).name === 'AbortError') return;
+        setError('Unable to load mentors at this time.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchMentors();
+
+    return () => controller.abort();
+  }, []);
 
   useEffect(() => {
     const category = parseCategoryParam(searchParams.get('expertise')) ?? 'All';
@@ -203,7 +234,7 @@ export default function MentorDiscoveryLayout() {
     }
   }, [activeCategory, activeAvailability, minRate, maxRate, pathname, router, searchParams]);
 
-  const filtered = mentors.filter(m => {
+  const filtered = mentorList.filter(m => {
     const matchesCategory = activeCategory === 'All' || m.category === activeCategory;
     const matchesAvailability =
       activeAvailability === 'All' ||
@@ -230,7 +261,9 @@ export default function MentorDiscoveryLayout() {
           Find your mentor
         </h1>
         <p className="mt-2 text-[15px] text-[#6b6860]">
-          Browse {mentors.length} experienced professionals ready to guide your journey.
+          {loading
+            ? 'Loading mentors from backend...'
+            : `Browse ${mentorList.length} experienced professionals ready to guide your journey.`}
         </p>
       </div>
 
@@ -292,7 +325,18 @@ export default function MentorDiscoveryLayout() {
               mentor{filtered.length !== 1 ? 's' : ''} found
             </p>
 
-            {filtered.length === 0 ? (
+            {loading ? (
+              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-5">
+                {[...Array(6)].map((_, index) => (
+                  <MentorCardSkeleton key={index} />
+                ))}
+              </div>
+            ) : error ? (
+              <div className="rounded-3xl bg-white border border-[rgba(20,18,16,0.07)] p-12 text-center">
+                <p className="text-[15px] text-[#141210] font-semibold mb-3">Unable to load mentors</p>
+                <p className="text-[14px] text-[#6b6860]">{error}</p>
+              </div>
+            ) : filtered.length === 0 ? (
               <div className="text-center py-16 text-[#94928d] text-[15px]">
                 No mentors match the selected filters.
               </div>

--- a/lib/mentors.ts
+++ b/lib/mentors.ts
@@ -1,5 +1,3 @@
-'use client';
-
 export type Mentor = {
   id: number;
   name: string;


### PR DESCRIPTION
Implemented backend-backed mentor listings with loading and error handling.

What changed
Added API endpoint: [route.ts](https://didactic-space-meme-g9ppr4xj6rq2vv9r.github.dev/)

returns mentor data from [@/lib/mentors](https://didactic-space-meme-g9ppr4xj6rq2vv9r.github.dev/)
supports optional query filtering by expertise, [availability](https://didactic-space-meme-g9ppr4xj6rq2vv9r.github.dev/), [minRate](https://didactic-space-meme-g9ppr4xj6rq2vv9r.github.dev/), [maxRate](https://didactic-space-meme-g9ppr4xj6rq2vv9r.github.dev/)
Updated mentor listing UI: [MentorDiscoveryLayout.tsx](https://didactic-space-meme-g9ppr4xj6rq2vv9r.github.dev/)

fetches mentor data from [/api/mentors](https://didactic-space-meme-g9ppr4xj6rq2vv9r.github.dev/)
handles:
loading state with skeleton cards
error state with user-facing message
continues to apply UI filters locally
still syncs filters to URL
Fixed shared data module: removed 'use client' from [mentors.ts](https://didactic-space-meme-g9ppr4xj6rq2vv9r.github.dev/) so server route can import it
closes #384 