### PR TITLE
feat: add CategoryBadge and ResourceCategoryCard components

### DIFF
--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -51,7 +51,7 @@ export default function Home() {
             <p className="mb-6 font-light text-gray-500 md:text-lg dark:text-gray-400">Flowbite helps you connect with friends and communities of people who share your interests. Connecting with your friends and family as well as discovering new ones is easy with features like Groups.</p>
             <a href="#" className="inline-flex items-center text-white bg-primary-700 hover:bg-primary-800 focus:ring-4 focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:focus:ring-primary-900">
               Get started
-              <svg className="ml-2 -mr-1 w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
+              <svg className="ml-2 -mr-1 w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clipRule="evenodd"></path></svg>
             </a>
           </div>
         </div>

--- a/components/CategoryBadge.tsx
+++ b/components/CategoryBadge.tsx
@@ -1,0 +1,12 @@
+interface CategoryBadgeProps {
+  category: string;
+  color?: string;
+}
+
+export default function CategoryBadge({ category, color = 'bg-cyan-100 text-cyan-700' }: CategoryBadgeProps) {
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${color}`}>
+      {category}
+    </span>
+  );
+}

--- a/components/MentorCard.tsx
+++ b/components/MentorCard.tsx
@@ -12,7 +12,7 @@ export default function MentorCard({ name, role, description, avatarUrl }: Mento
   return (
     <div className="max-w-sm bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
       <a href="#">
-        <Image className="rounded-t-lg" src={avatarUrl} alt={`Avatar of ${name}`} width={400} height={300} objectFit="cover" />
+        <Image className="rounded-t-lg object-cover" src={avatarUrl} alt={`Avatar of ${name}`} width={400} height={300} />
       </a>
       <div className="p-5">
         <a href="#">

--- a/components/ResourceCategoryCard.tsx
+++ b/components/ResourceCategoryCard.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+interface ResourceCategoryCardProps {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  link: string;
+}
+
+export default function ResourceCategoryCard({ icon, title, description, link }: ResourceCategoryCardProps) {
+  return (
+    <Link href={link} className="group block">
+      <article className="flex h-full flex-col items-start gap-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition duration-300 hover:-translate-y-1 hover:border-cyan-300 hover:shadow-lg">
+        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-cyan-50 text-cyan-600 transition duration-300 group-hover:bg-cyan-100">
+          {icon}
+        </div>
+        <div className="space-y-2">
+          <h4 className="text-lg font-semibold text-slate-900">{title}</h4>
+          <p className="text-sm leading-relaxed text-slate-600">{description}</p>
+        </div>
+      </article>
+    </Link>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,18 @@
+import { ButtonHTMLAttributes } from 'react';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+}
+
+export function Button({ children, variant = 'primary', className = '', ...props }: ButtonProps) {
+  const base = 'inline-flex items-center justify-center rounded-lg px-5 py-2.5 text-sm font-medium focus:outline-none focus:ring-4 transition';
+  const variants = {
+    primary: 'bg-cyan-600 text-white hover:bg-cyan-700 focus:ring-cyan-300',
+    secondary: 'bg-white text-gray-900 border border-gray-200 hover:bg-gray-100 focus:ring-gray-200',
+  };
+  return (
+    <button className={`${base} ${variants[variant]} ${className}`} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Implements two new reusable components and fixes workflow build errors.

## Changes

### New Components
- **CategoryBadge** (#442): Small rounded badge with dynamic background color and `category` prop
- **ResourceCategoryCard** (#439): Reusable card component with typed `icon`, `title`, `description`, and `link` props

### Build Fixes
- Added missing `components/ui/button.tsx` Button component that `page.tsx` imports
- Fixed JSX attribute names: `fill-rule` → `fillRule`, `clip-rule` → `clipRule`
- Fixed deprecated `objectFit` prop in `MentorCard` (moved to Tailwind className)

## Closes
Closes #442
Closes #439