### PR TITLE
feat: add LearningTrackCard and QuickAccessSection components

### DIFF
--- a/components/LearningTrackCard.tsx
+++ b/components/LearningTrackCard.tsx
@@ -1,0 +1,41 @@
+import Image from 'next/image';
+
+interface LearningTrackCardProps {
+  imageUrl: string;
+  category: string;
+  title: string;
+  description: string;
+  lessonCount: number;
+  duration: string;
+}
+
+export default function LearningTrackCard({
+  imageUrl,
+  category,
+  title,
+  description,
+  lessonCount,
+  duration,
+}: LearningTrackCardProps) {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow overflow-hidden flex flex-col">
+      <div className="relative w-full aspect-video">
+        <Image src={imageUrl} alt={title} fill className="object-cover" />
+      </div>
+      <div className="p-5 flex flex-col flex-1">
+        <span className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-400 mb-2">
+          {category}
+        </span>
+        <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-1">{title}</h3>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4 flex-1">{description}</p>
+        <div className="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400 mb-4">
+          <span>{lessonCount} lessons</span>
+          <span>{duration}</span>
+        </div>
+        <button className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 rounded-lg transition-colors">
+          Start Learning
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/QuickAccessSection.tsx
+++ b/components/QuickAccessSection.tsx
@@ -1,0 +1,48 @@
+interface QuickAccessItem {
+  icon: string;
+  title: string;
+  description: string;
+}
+
+const items: QuickAccessItem[] = [
+  {
+    icon: '📄',
+    title: 'Resume Templates',
+    description: 'Professional templates to help you land your next role.',
+  },
+  {
+    icon: '🎬',
+    title: 'Video Tutorials',
+    description: 'Step-by-step video guides from industry experts.',
+  },
+  {
+    icon: '📚',
+    title: 'Career Guides',
+    description: 'In-depth resources to navigate your career path.',
+  },
+  {
+    icon: '🛠️',
+    title: 'Downloadable Tools',
+    description: 'Handy toolkits and templates you can use right away.',
+  },
+];
+
+export default function QuickAccessSection() {
+  return (
+    <section className="py-10 px-4">
+      <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">Quick Access</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {items.map((item) => (
+          <div
+            key={item.title}
+            className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5 flex flex-col gap-2 shadow hover:shadow-md hover:-translate-y-0.5 transition-all cursor-pointer"
+          >
+            <span className="text-3xl">{item.icon}</span>
+            <h3 className="font-semibold text-gray-900 dark:text-white">{item.title}</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400">{item.description}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,14 @@
+import { ButtonHTMLAttributes } from 'react';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'outline';
+}
+
+export function Button({ className = '', variant = 'default', ...props }: ButtonProps) {
+  const base = 'inline-flex items-center justify-center rounded-lg px-5 py-2.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2';
+  const variants = {
+    default: 'bg-indigo-600 text-white hover:bg-indigo-700 focus:ring-indigo-500',
+    outline: 'border border-gray-300 text-gray-700 hover:bg-gray-50 focus:ring-indigo-500',
+  };
+  return <button className={`${base} ${variants[variant]} ${className}`} {...props} />;
+}


### PR DESCRIPTION
## Summary

Closes #438 
Closes #441 

### LearningTrackCard (closes #441)
- Reusable card component for learning tracks
- Includes: image (16:9 aspect-ratio), category tag, title, description, lesson count, duration, and a styled "Start Learning" button
- Responsive layout; dark mode support

### QuickAccessSection (closes #438)
- Grid layout for quick access resource categories
- Cards for: Resume Templates, Video Tutorials, Career Guides, Downloadable Tools
- Each card has icon + title + description
- Responsive grid: 4 → 2 → 1 columns
- Hover effects (shadow + slight translate)

### Also fixed
- Added `components/ui/button.tsx` — was missing and caused a pre-existing build error

## Testing
- `npm run build` passes with 0 errors