### PR TITLE
feat: implement authentication pages UI (#427, #428, #429, #430)

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      {children}
+    </div>
+  );
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,3 @@
+export default function LoginPage() {
+  return <div />;
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,3 +1,60 @@
 export default function LoginPage() {
-  return <div />;
+  return (
+    <div className="w-full max-w-md bg-white rounded-2xl shadow-md p-8">
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">Welcome back</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        Don&apos;t have an account?{" "}
+        <a href="/register" className="text-purple-600 font-medium hover:underline">
+          Sign up
+        </a>
+      </p>
+
+      <form className="space-y-4">
+        <div>
+          <label
+            htmlFor="email"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            placeholder="you@example.com"
+            className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition"
+          />
+        </div>
+
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Password
+            </label>
+            <a
+              href="/forgot-password"
+              className="text-sm text-purple-600 hover:underline"
+            >
+              Forgot password?
+            </a>
+          </div>
+          <input
+            id="password"
+            type="password"
+            placeholder="••••••••"
+            className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition"
+          />
+        </div>
+
+        <button
+          type="submit"
+          className="w-full bg-purple-600 hover:bg-purple-700 text-white font-semibold py-2.5 rounded-lg transition focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
+        >
+          Log In
+        </button>
+      </form>
+    </div>
+  );
 }

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -9,6 +9,49 @@ export default function LoginPage() {
         </a>
       </p>
 
+      <div className="space-y-3">
+        <button
+          type="button"
+          className="w-full flex items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+            <path
+              d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615Z"
+              fill="#4285F4"
+            />
+            <path
+              d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18Z"
+              fill="#34A853"
+            />
+            <path
+              d="M3.964 10.706A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.706V4.962H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.038l3.007-2.332Z"
+              fill="#FBBC05"
+            />
+            <path
+              d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.962L3.964 7.294C4.672 5.163 6.656 3.58 9 3.58Z"
+              fill="#EA4335"
+            />
+          </svg>
+          Continue with Google
+        </button>
+
+        <button
+          type="button"
+          className="w-full flex items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" fill="#1877F2">
+            <path d="M24 12.073C24 5.405 18.627 0 12 0S0 5.405 0 12.073C0 18.1 4.388 23.094 10.125 24v-8.437H7.078v-3.49h3.047V9.41c0-3.025 1.792-4.697 4.533-4.697 1.312 0 2.686.236 2.686.236v2.971h-1.513c-1.491 0-1.956.93-1.956 1.883v2.27h3.328l-.532 3.49h-2.796V24C19.612 23.094 24 18.1 24 12.073Z" />
+          </svg>
+          Continue with Facebook
+        </button>
+      </div>
+
+      <div className="flex items-center my-6">
+        <div className="flex-1 border-t border-gray-200" />
+        <span className="mx-4 text-xs text-gray-400 uppercase tracking-wide">or</span>
+        <div className="flex-1 border-t border-gray-200" />
+      </div>
+
       <form className="space-y-4">
         <div>
           <label

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,0 +1,3 @@
+export default function RegisterPage() {
+  return <div />;
+}

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -9,6 +9,49 @@ export default function RegisterPage() {
         </a>
       </p>
 
+      <div className="space-y-3">
+        <button
+          type="button"
+          className="w-full flex items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+            <path
+              d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615Z"
+              fill="#4285F4"
+            />
+            <path
+              d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18Z"
+              fill="#34A853"
+            />
+            <path
+              d="M3.964 10.706A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.706V4.962H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.038l3.007-2.332Z"
+              fill="#FBBC05"
+            />
+            <path
+              d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.962L3.964 7.294C4.672 5.163 6.656 3.58 9 3.58Z"
+              fill="#EA4335"
+            />
+          </svg>
+          Continue with Google
+        </button>
+
+        <button
+          type="button"
+          className="w-full flex items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" fill="#1877F2">
+            <path d="M24 12.073C24 5.405 18.627 0 12 0S0 5.405 0 12.073C0 18.1 4.388 23.094 10.125 24v-8.437H7.078v-3.49h3.047V9.41c0-3.025 1.792-4.697 4.533-4.697 1.312 0 2.686.236 2.686.236v2.971h-1.513c-1.491 0-1.956.93-1.956 1.883v2.27h3.328l-.532 3.49h-2.796V24C19.612 23.094 24 18.1 24 12.073Z" />
+          </svg>
+          Continue with Facebook
+        </button>
+      </div>
+
+      <div className="flex items-center my-6">
+        <div className="flex-1 border-t border-gray-200" />
+        <span className="mx-4 text-xs text-gray-400 uppercase tracking-wide">or</span>
+        <div className="flex-1 border-t border-gray-200" />
+      </div>
+
       <form className="space-y-4">
         <div>
           <label

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,3 +1,82 @@
 export default function RegisterPage() {
-  return <div />;
+  return (
+    <div className="w-full max-w-md bg-white rounded-2xl shadow-md p-8">
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">Create an account</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        Already have an account?{" "}
+        <a href="/login" className="text-purple-600 font-medium hover:underline">
+          Sign in
+        </a>
+      </p>
+
+      <form className="space-y-4">
+        <div>
+          <label
+            htmlFor="fullName"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Full Name
+          </label>
+          <input
+            id="fullName"
+            type="text"
+            placeholder="John Doe"
+            className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="email"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            placeholder="you@example.com"
+            className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="password"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            placeholder="••••••••"
+            className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="confirmPassword"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Confirm Password
+          </label>
+          <input
+            id="confirmPassword"
+            type="password"
+            placeholder="••••••••"
+            className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition"
+          />
+        </div>
+
+        <button
+          type="submit"
+          className="w-full bg-purple-600 hover:bg-purple-700 text-white font-semibold py-2.5 rounded-lg transition focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
+        >
+          Create Account
+        </button>
+      </form>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

This PR sets up the complete authentication UI for the SkillSync frontend, covering route structure, login form, registration form, and social authentication buttons across four incremental commits.

---

## Changes

### #427 — Authentication Route Structure
- Created the `(auth)` route group under `app/` using Next.js App Router conventions
- Added a shared `layout.tsx` that centers all auth pages on a gray background
- Added placeholder `login/page.tsx` and `register/page.tsx` files so both routes load immediately

### #428 — Registration Form UI
- Built the registration page with four input fields: **Full Name**, **Email**, **Password**, and **Confirm Password**
- Styled with Tailwind: rounded inputs, visible focus rings (purple), proper label spacing
- Purple **Create Account** primary button
- Clean card layout with a link to the login page
- Fully responsive (max-width card, fluid on mobile)

### #429 — Login Form UI
- Built the login page with **Email** and **Password** inputs
- **Forgot password?** link aligned to the right of the password label
- Purple **Log In** primary button
- Link to the registration page for new users
- Responsive card layout matching the registration page

### #430 — Social Authentication Buttons UI
- Added **Continue with Google** and **Continue with Facebook** buttons to both login and register pages
- Inline SVG icons (Google multi-color logo, Facebook blue logo) — no external icon library required
- Buttons are full-width, bordered, and hover to a light gray background
- An **"or"** text divider with horizontal rules separates the social buttons from the email/password form
- No backend integration — UI only

---

## File Structure

```
app/
└── (auth)/
    ├── layout.tsx          # shared centered layout
    ├── login/
    │   └── page.tsx        # login form + social buttons
    └── register/
        └── page.tsx        # registration form + social buttons
```

---

## Closes

Closes #427
Closes #428
Closes #429
Closes #430