### PR TITLE
feat: implement auth layout, navbar, password toggle, and form validation

### DIFF
--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Navbar from '@/components/navigation/Navbar';
 
 export default function PublicLayout({
   children,
@@ -6,9 +7,9 @@ export default function PublicLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div>
-      <h1>Public Layout</h1>
-      {children}
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="flex-1">{children}</main>
     </div>
   );
 }

--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -1,0 +1,51 @@
+import AuthLayout from '@/components/auth/AuthLayout';
+import Link from 'next/link';
+
+export default function LoginPage() {
+  return (
+    <AuthLayout>
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900 mb-2">Welcome back</h1>
+        <p className="text-gray-500 mb-8">
+          Don&apos;t have an account?{' '}
+          <Link href="/register" className="text-cyan-600 hover:underline font-medium">
+            Sign up
+          </Link>
+        </p>
+
+        <form className="flex flex-col gap-5">
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="email" className="text-sm font-medium text-gray-700">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              placeholder="you@example.com"
+              className="border border-gray-300 rounded-lg px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="password" className="text-sm font-medium text-gray-700">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              placeholder="••••••••"
+              className="border border-gray-300 rounded-lg px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="bg-cyan-600 text-white py-2.5 rounded-lg text-sm font-medium hover:bg-cyan-700 transition-colors"
+          >
+            Login
+          </button>
+        </form>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -1,4 +1,5 @@
 import AuthLayout from '@/components/auth/AuthLayout';
+import PasswordInput from '@/components/auth/PasswordInput';
 import Link from 'next/link';
 
 export default function LoginPage() {
@@ -30,12 +31,7 @@ export default function LoginPage() {
             <label htmlFor="password" className="text-sm font-medium text-gray-700">
               Password
             </label>
-            <input
-              id="password"
-              type="password"
-              placeholder="••••••••"
-              className="border border-gray-300 rounded-lg px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
-            />
+            <PasswordInput id="password" placeholder="••••••••" />
           </div>
 
           <button

--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -1,47 +1,10 @@
 import AuthLayout from '@/components/auth/AuthLayout';
-import PasswordInput from '@/components/auth/PasswordInput';
-import Link from 'next/link';
+import LoginForm from '@/components/auth/LoginForm';
 
 export default function LoginPage() {
   return (
     <AuthLayout>
-      <div>
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">Welcome back</h1>
-        <p className="text-gray-500 mb-8">
-          Don&apos;t have an account?{' '}
-          <Link href="/register" className="text-cyan-600 hover:underline font-medium">
-            Sign up
-          </Link>
-        </p>
-
-        <form className="flex flex-col gap-5">
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="email" className="text-sm font-medium text-gray-700">
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              placeholder="you@example.com"
-              className="border border-gray-300 rounded-lg px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
-            />
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="password" className="text-sm font-medium text-gray-700">
-              Password
-            </label>
-            <PasswordInput id="password" placeholder="••••••••" />
-          </div>
-
-          <button
-            type="submit"
-            className="bg-cyan-600 text-white py-2.5 rounded-lg text-sm font-medium hover:bg-cyan-700 transition-colors"
-          >
-            Login
-          </button>
-        </form>
-      </div>
+      <LoginForm />
     </AuthLayout>
   );
 }

--- a/app/(public)/register/page.tsx
+++ b/app/(public)/register/page.tsx
@@ -1,0 +1,75 @@
+import AuthLayout from '@/components/auth/AuthLayout';
+import Link from 'next/link';
+
+export default function RegisterPage() {
+  return (
+    <AuthLayout>
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900 mb-2">Create an account</h1>
+        <p className="text-gray-500 mb-8">
+          Already have an account?{' '}
+          <Link href="/login" className="text-cyan-600 hover:underline font-medium">
+            Login
+          </Link>
+        </p>
+
+        <form className="flex flex-col gap-5">
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="name" className="text-sm font-medium text-gray-700">
+              Full Name
+            </label>
+            <input
+              id="name"
+              type="text"
+              placeholder="Jane Doe"
+              className="border border-gray-300 rounded-lg px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="email" className="text-sm font-medium text-gray-700">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              placeholder="you@example.com"
+              className="border border-gray-300 rounded-lg px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="password" className="text-sm font-medium text-gray-700">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              placeholder="••••••••"
+              className="border border-gray-300 rounded-lg px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="confirmPassword" className="text-sm font-medium text-gray-700">
+              Confirm Password
+            </label>
+            <input
+              id="confirmPassword"
+              type="password"
+              placeholder="••••••••"
+              className="border border-gray-300 rounded-lg px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="bg-cyan-600 text-white py-2.5 rounded-lg text-sm font-medium hover:bg-cyan-700 transition-colors"
+          >
+            Create Account
+          </button>
+        </form>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/app/(public)/register/page.tsx
+++ b/app/(public)/register/page.tsx
@@ -1,66 +1,10 @@
 import AuthLayout from '@/components/auth/AuthLayout';
-import PasswordInput from '@/components/auth/PasswordInput';
-import Link from 'next/link';
+import RegisterForm from '@/components/auth/RegisterForm';
 
 export default function RegisterPage() {
   return (
     <AuthLayout>
-      <div>
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">Create an account</h1>
-        <p className="text-gray-500 mb-8">
-          Already have an account?{' '}
-          <Link href="/login" className="text-cyan-600 hover:underline font-medium">
-            Login
-          </Link>
-        </p>
-
-        <form className="flex flex-col gap-5">
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="name" className="text-sm font-medium text-gray-700">
-              Full Name
-            </label>
-            <input
-              id="name"
-              type="text"
-              placeholder="Jane Doe"
-              className="border border-gray-300 rounded-lg px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
-            />
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="email" className="text-sm font-medium text-gray-700">
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              placeholder="you@example.com"
-              className="border border-gray-300 rounded-lg px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
-            />
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="password" className="text-sm font-medium text-gray-700">
-              Password
-            </label>
-            <PasswordInput id="password" placeholder="••••••••" />
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="confirmPassword" className="text-sm font-medium text-gray-700">
-              Confirm Password
-            </label>
-            <PasswordInput id="confirmPassword" placeholder="••••••••" />
-          </div>
-
-          <button
-            type="submit"
-            className="bg-cyan-600 text-white py-2.5 rounded-lg text-sm font-medium hover:bg-cyan-700 transition-colors"
-          >
-            Create Account
-          </button>
-        </form>
-      </div>
+      <RegisterForm />
     </AuthLayout>
   );
 }

--- a/app/(public)/register/page.tsx
+++ b/app/(public)/register/page.tsx
@@ -1,4 +1,5 @@
 import AuthLayout from '@/components/auth/AuthLayout';
+import PasswordInput from '@/components/auth/PasswordInput';
 import Link from 'next/link';
 
 export default function RegisterPage() {
@@ -42,24 +43,14 @@ export default function RegisterPage() {
             <label htmlFor="password" className="text-sm font-medium text-gray-700">
               Password
             </label>
-            <input
-              id="password"
-              type="password"
-              placeholder="••••••••"
-              className="border border-gray-300 rounded-lg px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
-            />
+            <PasswordInput id="password" placeholder="••••••••" />
           </div>
 
           <div className="flex flex-col gap-1.5">
             <label htmlFor="confirmPassword" className="text-sm font-medium text-gray-700">
               Confirm Password
             </label>
-            <input
-              id="confirmPassword"
-              type="password"
-              placeholder="••••••••"
-              className="border border-gray-300 rounded-lg px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
-            />
+            <PasswordInput id="confirmPassword" placeholder="••••••••" />
           </div>
 
           <button

--- a/components/auth/AuthLayout.tsx
+++ b/components/auth/AuthLayout.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+interface AuthLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function AuthLayout({ children }: AuthLayoutProps) {
+  return (
+    <div className="min-h-screen flex">
+      {/* Left side — form */}
+      <div className="flex flex-1 flex-col justify-center items-center px-6 py-12 bg-white">
+        <div className="w-full max-w-md">{children}</div>
+      </div>
+
+      {/* Right side — mentor highlight panel (hidden on mobile) */}
+      <div className="hidden lg:flex flex-1 flex-col justify-center items-center bg-gradient-to-br from-purple-700 via-purple-600 to-indigo-600 px-10 text-white">
+        {/* Mentor card */}
+        <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-6 max-w-sm w-full mb-8 border border-white/20">
+          <div className="flex items-center gap-4 mb-4">
+            <div className="w-14 h-14 rounded-full bg-white/30 flex items-center justify-center text-2xl font-bold text-white">
+              A
+            </div>
+            <div>
+              <p className="font-semibold text-lg">Amara Okonkwo</p>
+              <p className="text-purple-200 text-sm">Senior Engineer @ Stripe</p>
+            </div>
+          </div>
+          <div className="flex gap-0.5 mb-3">
+            {[1, 2, 3, 4, 5].map((star) => (
+              <svg key={star} className="w-4 h-4 text-yellow-400 fill-yellow-400" viewBox="0 0 20 20">
+                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+              </svg>
+            ))}
+          </div>
+          <p className="text-purple-100 text-sm leading-relaxed">
+            "Mentoring on SkillSync changed how I share expertise. The platform makes it effortless to connect with driven learners."
+          </p>
+        </div>
+
+        {/* Testimonial */}
+        <div className="max-w-sm text-center">
+          <h2 className="text-2xl font-bold leading-snug mb-3">
+            Grow confidently with support from skilled mentors who care
+          </h2>
+          <p className="text-purple-200 text-sm">
+            Join thousands of learners accelerating their careers with personalised mentorship.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import Link from 'next/link';
+import PasswordInput from './PasswordInput';
+
+const loginSchema = z.object({
+  email: z.string().min(1, 'Email is required').email('Enter a valid email address'),
+  password: z.string().min(1, 'Password is required'),
+});
+
+type LoginFormValues = z.infer<typeof loginSchema>;
+
+export default function LoginForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid, isDirty },
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    mode: 'onTouched',
+  });
+
+  const onSubmit = (data: LoginFormValues) => {
+    console.log('Login:', data);
+  };
+
+  return (
+    <div>
+      <h1 className="text-3xl font-bold text-gray-900 mb-2">Welcome back</h1>
+      <p className="text-gray-500 mb-8">
+        Don&apos;t have an account?{' '}
+        <Link href="/register" className="text-cyan-600 hover:underline font-medium">
+          Sign up
+        </Link>
+      </p>
+
+      <form onSubmit={handleSubmit(onSubmit)} noValidate className="flex flex-col gap-5">
+        {/* Email */}
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="email" className="text-sm font-medium text-gray-700">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            placeholder="you@example.com"
+            {...register('email')}
+            aria-invalid={!!errors.email}
+            className={`border rounded-lg px-3 py-2.5 text-sm outline-none focus:ring-2 transition ${
+              errors.email
+                ? 'border-red-400 focus:ring-red-300 focus:border-red-400'
+                : 'border-gray-300 focus:ring-cyan-500 focus:border-cyan-500'
+            }`}
+          />
+          {errors.email && (
+            <p role="alert" className="text-xs text-red-500">
+              {errors.email.message}
+            </p>
+          )}
+        </div>
+
+        {/* Password */}
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="password" className="text-sm font-medium text-gray-700">
+            Password
+          </label>
+          <PasswordInput
+            id="password"
+            placeholder="••••••••"
+            {...register('password')}
+            aria-invalid={!!errors.password}
+            className={errors.password ? 'border-red-400 focus:ring-red-300 focus:border-red-400' : ''}
+          />
+          {errors.password && (
+            <p role="alert" className="text-xs text-red-500">
+              {errors.password.message}
+            </p>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          disabled={isDirty && !isValid}
+          className="bg-cyan-600 text-white py-2.5 rounded-lg text-sm font-medium hover:bg-cyan-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/components/auth/PasswordInput.tsx
+++ b/components/auth/PasswordInput.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState, forwardRef, InputHTMLAttributes } from 'react';
+
+interface PasswordInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  id: string;
+}
+
+const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
+  ({ className = '', ...props }, ref) => {
+    const [visible, setVisible] = useState(false);
+
+    return (
+      <div className="relative">
+        <input
+          {...props}
+          ref={ref}
+          type={visible ? 'text' : 'password'}
+          className={`border border-gray-300 rounded-lg px-3 py-2.5 pr-10 text-sm w-full outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition ${className}`}
+        />
+        <button
+          type="button"
+          onClick={() => setVisible((v) => !v)}
+          aria-label={visible ? 'Hide password' : 'Show password'}
+          className="absolute inset-y-0 right-0 flex items-center px-3 text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          {visible ? (
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+            </svg>
+          ) : (
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+            </svg>
+          )}
+        </button>
+      </div>
+    );
+  }
+);
+
+PasswordInput.displayName = 'PasswordInput';
+
+export default PasswordInput;

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import Link from 'next/link';
+import PasswordInput from './PasswordInput';
+
+const registerSchema = z
+  .object({
+    name: z.string().min(1, 'Full name is required'),
+    email: z.string().min(1, 'Email is required').email('Enter a valid email address'),
+    password: z.string().min(8, 'Password must be at least 8 characters'),
+    confirmPassword: z.string().min(1, 'Please confirm your password'),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ['confirmPassword'],
+  });
+
+type RegisterFormValues = z.infer<typeof registerSchema>;
+
+export default function RegisterForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid, isDirty },
+  } = useForm<RegisterFormValues>({
+    resolver: zodResolver(registerSchema),
+    mode: 'onTouched',
+  });
+
+  const onSubmit = (data: RegisterFormValues) => {
+    console.log('Register:', data);
+  };
+
+  const fieldClass = (hasError: boolean) =>
+    `border rounded-lg px-3 py-2.5 text-sm w-full outline-none focus:ring-2 transition ${
+      hasError
+        ? 'border-red-400 focus:ring-red-300 focus:border-red-400'
+        : 'border-gray-300 focus:ring-cyan-500 focus:border-cyan-500'
+    }`;
+
+  return (
+    <div>
+      <h1 className="text-3xl font-bold text-gray-900 mb-2">Create an account</h1>
+      <p className="text-gray-500 mb-8">
+        Already have an account?{' '}
+        <Link href="/login" className="text-cyan-600 hover:underline font-medium">
+          Login
+        </Link>
+      </p>
+
+      <form onSubmit={handleSubmit(onSubmit)} noValidate className="flex flex-col gap-5">
+        {/* Full Name */}
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="name" className="text-sm font-medium text-gray-700">
+            Full Name
+          </label>
+          <input
+            id="name"
+            type="text"
+            placeholder="Jane Doe"
+            {...register('name')}
+            aria-invalid={!!errors.name}
+            className={fieldClass(!!errors.name)}
+          />
+          {errors.name && (
+            <p role="alert" className="text-xs text-red-500">
+              {errors.name.message}
+            </p>
+          )}
+        </div>
+
+        {/* Email */}
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="email" className="text-sm font-medium text-gray-700">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            placeholder="you@example.com"
+            {...register('email')}
+            aria-invalid={!!errors.email}
+            className={fieldClass(!!errors.email)}
+          />
+          {errors.email && (
+            <p role="alert" className="text-xs text-red-500">
+              {errors.email.message}
+            </p>
+          )}
+        </div>
+
+        {/* Password */}
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="password" className="text-sm font-medium text-gray-700">
+            Password
+          </label>
+          <PasswordInput
+            id="password"
+            placeholder="••••••••"
+            {...register('password')}
+            aria-invalid={!!errors.password}
+            className={errors.password ? 'border-red-400 focus:ring-red-300 focus:border-red-400' : ''}
+          />
+          {errors.password && (
+            <p role="alert" className="text-xs text-red-500">
+              {errors.password.message}
+            </p>
+          )}
+        </div>
+
+        {/* Confirm Password */}
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="confirmPassword" className="text-sm font-medium text-gray-700">
+            Confirm Password
+          </label>
+          <PasswordInput
+            id="confirmPassword"
+            placeholder="••••••••"
+            {...register('confirmPassword')}
+            aria-invalid={!!errors.confirmPassword}
+            className={errors.confirmPassword ? 'border-red-400 focus:ring-red-300 focus:border-red-400' : ''}
+          />
+          {errors.confirmPassword && (
+            <p role="alert" className="text-xs text-red-500">
+              {errors.confirmPassword.message}
+            </p>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          disabled={isDirty && !isValid}
+          className="bg-cyan-600 text-white py-2.5 rounded-lg text-sm font-medium hover:bg-cyan-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Create Account
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/components/navigation/Navbar.tsx
+++ b/components/navigation/Navbar.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const navLinks = [
+  { label: 'Home', href: '/' },
+  { label: 'Discover Mentors', href: '/discover-mentors' },
+  { label: 'How It Works', href: '/how-it-works' },
+  { label: 'Pricing', href: '/pricing' },
+];
+
+export default function Navbar() {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const pathname = usePathname();
+
+  return (
+    <header className="sticky top-0 z-50 bg-white border-b border-gray-200 shadow-sm">
+      <nav className="max-w-screen-xl mx-auto px-4 py-3 flex items-center justify-between">
+        {/* Logo */}
+        <Link href="/" className="text-xl font-bold text-cyan-600 tracking-tight">
+          SkillSync
+        </Link>
+
+        {/* Desktop nav links */}
+        <ul className="hidden md:flex items-center gap-6">
+          {navLinks.map(({ label, href }) => (
+            <li key={href}>
+              <Link
+                href={href}
+                className={`text-sm font-medium transition-colors hover:text-cyan-600 ${
+                  pathname === href ? 'text-cyan-600 border-b-2 border-cyan-600 pb-0.5' : 'text-gray-600'
+                }`}
+              >
+                {label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+
+        {/* Auth buttons (desktop) */}
+        <div className="hidden md:flex items-center gap-3">
+          <Link
+            href="/login"
+            className="text-sm font-medium text-gray-700 hover:text-cyan-600 transition-colors"
+          >
+            Login
+          </Link>
+          <Link
+            href="/register"
+            className="text-sm font-medium bg-cyan-600 text-white px-4 py-2 rounded-lg hover:bg-cyan-700 transition-colors"
+          >
+            Register
+          </Link>
+        </div>
+
+        {/* Hamburger button (mobile) */}
+        <button
+          className="md:hidden p-2 rounded-lg text-gray-600 hover:bg-gray-100 transition-colors"
+          onClick={() => setMenuOpen((prev) => !prev)}
+          aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+          aria-expanded={menuOpen}
+          aria-controls="mobile-menu"
+        >
+          {menuOpen ? (
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          ) : (
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          )}
+        </button>
+      </nav>
+
+      {/* Mobile menu */}
+      {menuOpen && (
+        <div id="mobile-menu" className="md:hidden border-t border-gray-100 bg-white px-4 pb-4">
+          <ul className="flex flex-col gap-1 mt-2">
+            {navLinks.map(({ label, href }) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  onClick={() => setMenuOpen(false)}
+                  className={`block py-2 px-3 rounded-lg text-sm font-medium transition-colors hover:bg-gray-50 hover:text-cyan-600 ${
+                    pathname === href ? 'text-cyan-600 bg-cyan-50' : 'text-gray-700'
+                  }`}
+                >
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+          <div className="flex flex-col gap-2 mt-3 pt-3 border-t border-gray-100">
+            <Link
+              href="/login"
+              onClick={() => setMenuOpen(false)}
+              className="text-center text-sm font-medium text-gray-700 border border-gray-200 py-2 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              Login
+            </Link>
+            <Link
+              href="/register"
+              onClick={() => setMenuOpen(false)}
+              className="text-center text-sm font-medium bg-cyan-600 text-white py-2 rounded-lg hover:bg-cyan-700 transition-colors"
+            >
+              Register
+            </Link>
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,12 @@
       "name": "skillsync_frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.4.0",
         "next": "16.2.9",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "react-hook-form": "^7.80.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -451,6 +454,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1251,6 +1266,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -5557,6 +5578,22 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.80.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.80.0.tgz",
+      "integrity": "sha512-4P+fk6oXsxY+6xSj7Euhc2sumQD8zQqCuVHoJwoyp9EchP+IUW9OESB7uHFJOKsIBQ4MQqYE84INJFqUCYNoOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6680,7 +6717,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.4.0",
     "next": "16.2.9",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "react-hook-form": "^7.80.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary

This PR implements four features for the public section of the SkillSync platform, covering authentication UI, navigation, and form behaviour.

---

### #434 — Global Navigation Bar (Public Section)

- Added `components/navigation/Navbar.tsx` as a sticky, responsive navigation bar
- Desktop: horizontal nav links (Home, Discover Mentors, How It Works, Pricing) with Login and Register auth buttons on the right
- Mobile: hamburger icon toggles a slide-down dropdown menu with the same links and auth buttons
- Active link is highlighted using `usePathname`
- Smooth hover transitions via Tailwind
- Accessible hamburger button with `aria-label` and `aria-expanded`
- Integrated into `app/(public)/layout.tsx`, replacing the placeholder content

---

### #431 — Split-Screen Authentication Layout

- Added `components/auth/AuthLayout.tsx` — a reusable wrapper for auth pages
- **Left panel:** white background, centres the form content, max width constrained
- **Right panel:** purple-to-indigo gradient (`from-purple-700 via-purple-600 to-indigo-600`), visible on `lg` screens and above only
  - Featured mentor card with avatar, name, role, star rating, and quote
  - Testimonial text: *"Grow confidently with support from skilled mentors who care"*
- Created `app/(public)/login/page.tsx` and `app/(public)/register/page.tsx` using `AuthLayout`
- Mobile: right panel hidden, form takes full width

---

### #433 — Password Visibility Toggle

- Added `components/auth/PasswordInput.tsx` — a `forwardRef` input component
- Eye icon sits absolutely inside the input (no layout shift)
- Clicking toggles between `type="password"` and `type="text"`
- Toggle button has accessible `aria-label` ("Show password" / "Hide password")
- Compatible with `react-hook-form`'s `register` spread via `forwardRef`
- Wired into password and confirm-password fields on both login and register forms

---

### #432 — Client-Side Form Validation

- Installed `react-hook-form`, `zod`, and `@hookform/resolvers`
- **`LoginForm.tsx`** (`'use client'`):
  - Email: required + valid email format
  - Password: required
- **`RegisterForm.tsx`** (`'use client'`):
  - Full Name: required
  - Email: required + valid email format
  - Password: required, minimum 8 characters
  - Confirm Password: required, must match password (`z.refine`)
- Errors display below each field with `role="alert"` for accessibility
- Input borders turn red on invalid fields
- Submit button disabled (`opacity-50`, `cursor-not-allowed`) while the form has validation errors after first interaction (`mode: 'onTouched'`)

---

## Closes

Closes #431
Closes #432
Closes #433
Closes #434