### PR TITLE
feat: add loading skeleton UI for resource cards

### DIFF
--- a/components/skeletons/ArticleListItemSkeleton.tsx
+++ b/components/skeletons/ArticleListItemSkeleton.tsx
@@ -1,0 +1,16 @@
+export default function ArticleListItemSkeleton() {
+  return (
+    <div className="flex items-center justify-between gap-4 py-4 px-2">
+      <div className="flex flex-col gap-2 flex-1">
+        {/* category */}
+        <div className="h-3 w-16 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+        {/* title */}
+        <div className="h-5 w-2/3 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+        {/* author · read time */}
+        <div className="h-3 w-32 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+      </div>
+      {/* arrow icon placeholder */}
+      <div className="flex-shrink-0 h-8 w-8 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse" />
+    </div>
+  );
+}

--- a/components/skeletons/LearningTrackCardSkeleton.tsx
+++ b/components/skeletons/LearningTrackCardSkeleton.tsx
@@ -1,0 +1,24 @@
+export default function LearningTrackCardSkeleton() {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow overflow-hidden flex flex-col">
+      {/* image placeholder — same aspect-video as real card */}
+      <div className="w-full aspect-video bg-gray-200 dark:bg-gray-700 animate-pulse" />
+      <div className="p-5 flex flex-col flex-1 gap-2">
+        {/* category badge */}
+        <div className="h-3 w-16 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+        {/* title */}
+        <div className="h-5 w-3/4 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+        {/* description lines */}
+        <div className="h-3 w-full rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+        <div className="h-3 w-5/6 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+        {/* meta row */}
+        <div className="flex gap-4 mt-2">
+          <div className="h-3 w-20 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+          <div className="h-3 w-16 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+        </div>
+        {/* button */}
+        <div className="mt-4 h-9 w-full rounded-lg bg-gray-200 dark:bg-gray-700 animate-pulse" />
+      </div>
+    </div>
+  );
+}

--- a/components/skeletons/QuickAccessCardSkeleton.tsx
+++ b/components/skeletons/QuickAccessCardSkeleton.tsx
@@ -1,0 +1,13 @@
+export default function QuickAccessCardSkeleton() {
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5 flex flex-col gap-2 shadow">
+      {/* emoji icon */}
+      <div className="h-9 w-9 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+      {/* title */}
+      <div className="h-4 w-3/4 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+      {/* description */}
+      <div className="h-3 w-full rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+      <div className="h-3 w-4/5 rounded bg-gray-200 dark:bg-gray-700 animate-pulse" />
+    </div>
+  );
+}


### PR DESCRIPTION
closes #450 
Adds skeleton loader components for resource cards using Tailwind's animate-pulse.

Changes:

LearningTrackCardSkeleton.tsx
 — mirrors the image + content layout of LearningTrackCard
ArticleListItemSkeleton.tsx
 — mirrors the row layout of ArticleListItem
QuickAccessCardSkeleton.tsx
 — mirrors the card layout of the quick access items
Notes:

All skeletons match the exact dimensions and structure of their real counterparts to prevent layout shift
Dark mode supported via dark:bg-gray-700 placeholder colors