### PR TITLE
feat: implement Mentor Discovery page (/mentors) with search, filter sidebar, and industry filter

### DIFF
--- a/app/(public)/mentors/[mentorId]/page.tsx
+++ b/app/(public)/mentors/[mentorId]/page.tsx
@@ -1,16 +1,159 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import StarRating from '@/components/ui/StarRating';
+import MentorAvailabilityBadge from '@/components/MentorAvailabilityBadge';
+import { MENTORS, mentorSlug, type Mentor } from '../data/mockMentors';
+
 interface MentorProfilePageProps {
-  params: { mentorId: string };
+  params: Promise<{ mentorId: string }>;
 }
 
-export default function MentorProfilePage({ params }: MentorProfilePageProps) {
+export function generateStaticParams() {
+  return MENTORS.map((mentor) => ({ mentorId: mentorSlug(mentor) }));
+}
+
+function findMentor(rawId: string): Mentor | undefined {
+  // Accept either the canonical id or the humanised slug produced by
+  // `generateStaticParams` / `mentorSlug`.
+  const normalised = decodeURIComponent(rawId).toLowerCase();
+  return MENTORS.find(
+    (mentor) => mentor.id === rawId || mentorSlug(mentor) === normalised,
+  );
+}
+
+export default async function MentorProfilePage({ params }: MentorProfilePageProps) {
+  const { mentorId } = await params;
+  const mentor = findMentor(mentorId);
+  if (!mentor) notFound();
+
+  const profileSlug = mentorSlug(mentor);
+  const isUnavailable = mentor.availability === 'fully-booked';
+
   return (
-    <main className="max-w-3xl mx-auto px-4 py-12">
-      <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-        Mentor Profile
-      </h1>
-      <p className="mt-2 text-gray-600 dark:text-gray-400">
-        ID: {params.mentorId}
-      </p>
+    <main className="mx-auto max-w-3xl px-4 py-12">
+      <Link
+        href="/mentors"
+        className="inline-flex items-center gap-1.5 text-sm font-semibold text-cyan-600 transition-colors hover:text-cyan-700 dark:text-cyan-400 dark:hover:text-cyan-300"
+      >
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2.5}
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+        Back to mentors
+      </Link>
+
+      <div className="mt-6 rounded-2xl border border-gray-100 bg-white p-8 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-extrabold text-gray-900 dark:text-white">
+              {mentor.name}
+            </h1>
+            <p className="mt-1 text-base font-semibold text-cyan-600 dark:text-cyan-400">
+              {mentor.headline}
+            </p>
+          </div>
+          <MentorAvailabilityBadge status={mentor.availability} />
+        </div>
+
+        <div className="mt-4 flex items-center gap-2">
+          <StarRating rating={mentor.rating} size="sm" />
+          <span className="text-sm text-gray-600 dark:text-gray-400">
+            {mentor.rating.toFixed(1)} · {mentor.reviewCount.toLocaleString()} reviews
+          </span>
+        </div>
+
+        <p className="mt-6 text-base leading-relaxed text-gray-700 dark:text-gray-300">
+          {mentor.bio}
+        </p>
+
+        {mentor.skills.length > 0 ? (
+          <section className="mt-6" aria-labelledby={`skills-${profileSlug}`}>
+            <h2
+              id={`skills-${profileSlug}`}
+              className="text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+            >
+              Skills
+            </h2>
+            <ul className="mt-3 flex flex-wrap gap-2">
+              {mentor.skills.map((skill) => (
+                <li
+                  key={skill}
+                  className="inline-flex items-center rounded-full bg-cyan-50 px-3 py-1 text-sm font-medium text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300"
+                >
+                  {skill}
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+
+        {mentor.industries.length > 0 ? (
+          <section className="mt-6" aria-labelledby={`industries-${profileSlug}`}>
+            <h2
+              id={`industries-${profileSlug}`}
+              className="text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+            >
+              Industries
+            </h2>
+            <ul className="mt-3 flex flex-wrap gap-2">
+              {mentor.industries.map((industry) => (
+                <li
+                  key={industry}
+                  className="inline-flex items-center rounded-full bg-purple-50 px-3 py-1 text-sm font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
+                >
+                  {industry}
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+
+        <dl className="mt-6 grid grid-cols-2 gap-4 border-t border-gray-100 pt-6 text-sm dark:border-gray-800">
+          <div>
+            <dt className="text-gray-500 dark:text-gray-400">Experience</dt>
+            <dd className="mt-0.5 font-semibold text-gray-900 dark:text-white">
+              {mentor.experienceLevel} · {mentor.yearsExperience} yrs
+            </dd>
+          </div>
+          <div>
+            <dt className="text-gray-500 dark:text-gray-400">Per session</dt>
+            <dd className="mt-0.5 font-semibold text-gray-900 dark:text-white">
+              ${mentor.pricePerSession}
+            </dd>
+          </div>
+        </dl>
+
+        <div className="mt-8 flex flex-wrap items-center gap-3">
+          {isUnavailable ? (
+            <button
+              type="button"
+              disabled
+              className="cursor-not-allowed rounded-lg bg-gray-200 px-5 py-2.5 text-sm font-semibold text-gray-400 dark:bg-gray-800 dark:text-gray-500"
+            >
+              Currently unavailable
+            </button>
+          ) : (
+            <Link
+              href={`/book/${profileSlug}`}
+              className="rounded-lg bg-cyan-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-cyan-700 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2"
+            >
+              Book a session
+            </Link>
+          )}
+          <Link
+            href="/mentors"
+            className="rounded-lg border border-gray-200 px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            Find another mentor
+          </Link>
+        </div>
+      </div>
     </main>
   );
 }

--- a/app/(public)/mentors/components/DiscoveryMentorCard.tsx
+++ b/app/(public)/mentors/components/DiscoveryMentorCard.tsx
@@ -1,0 +1,214 @@
+import Link from 'next/link';
+import StarRating from '@/components/ui/StarRating';
+import MentorAvailabilityBadge from '@/components/MentorAvailabilityBadge';
+import {
+  mentorSlug,
+  type Mentor,
+} from '../data/mockMentors';
+
+interface DiscoveryMentorCardProps {
+  mentor: Mentor;
+}
+
+const AVATAR_GRADIENTS = [
+  'from-cyan-500 to-blue-600',
+  'from-purple-500 to-indigo-600',
+  'from-emerald-500 to-teal-600',
+  'from-pink-500 to-rose-600',
+  'from-amber-500 to-orange-600',
+];
+
+function initialsFromName(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((part) => part[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase();
+}
+
+function deterministicGradient(name: string): string {
+  // Hash by character code so the gradient is stable across renders.
+  const seed = name.split('').reduce((acc, ch) => acc + ch.charCodeAt(0), 0);
+  return AVATAR_GRADIENTS[seed % AVATAR_GRADIENTS.length];
+}
+
+/**
+ * Mentor card used inside the Discovery page.
+ *
+ * Built locally (instead of reusing the global MentorCard.tsx) because the
+ * global card has duplicate interface / export declarations that fail a
+ * strict compile. This component is purposely lean — it draws on the
+ * project's visual language (rounded-2xl, cyan accents, StarRating,
+ * MentorAvailabilityBadge) so it sits comfortably next to the rest of the
+ * site.
+ */
+export default function DiscoveryMentorCard({ mentor }: DiscoveryMentorCardProps) {
+  const profileHref = `/mentors/${mentorSlug(mentor)}`;
+  const gradient = deterministicGradient(mentor.name);
+  const initials = initialsFromName(mentor.name);
+
+  const unavailable = mentor.availability === 'fully-booked';
+
+  return (
+    <article className="group flex h-full flex-col overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:shadow-md dark:border-gray-800 dark:bg-gray-900">
+      {/* ── Body ─────────────────────────────────────────────── */}
+      <div className="flex flex-col gap-4 p-6">
+        <div className="flex items-start justify-between">
+          {/* Avatar (image fallback → gradient initials) */}
+          <div
+            className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br text-xl font-bold text-white shadow-md shadow-cyan-500/10 transition-transform duration-300 group-hover:scale-105 ${gradient}`}
+            aria-hidden="true"
+          >
+            {initials || 'M'}
+          </div>
+
+          <MentorAvailabilityBadge
+            status={mentor.availability}
+          />
+        </div>
+
+        <div>
+          <h3 className="text-xl font-bold leading-tight text-gray-900 transition-colors group-hover:text-cyan-600 dark:text-white dark:group-hover:text-cyan-400">
+            {mentor.name}
+          </h3>
+          <p className="mt-0.5 text-sm font-medium text-cyan-600 dark:text-cyan-400">
+            {mentor.headline}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <StarRating rating={mentor.rating} size="sm" />
+          <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+            {mentor.rating.toFixed(1)} · {mentor.reviewCount.toLocaleString()} reviews
+          </span>
+        </div>
+
+        <p className="line-clamp-3 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+          {mentor.bio}
+        </p>
+
+        {/* Skill chips */}
+        {mentor.skills.length > 0 ? (
+          <ul
+            role="list"
+            aria-label={`${mentor.name}'s skills`}
+            className="flex flex-wrap gap-1.5"
+          >
+            {mentor.skills.slice(0, 4).map((skill) => (
+              <li
+                key={skill}
+                className="inline-flex items-center rounded-full bg-cyan-50 px-2.5 py-0.5 text-xs font-medium text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300"
+              >
+                {skill}
+              </li>
+            ))}
+            {mentor.skills.length > 4 ? (
+              <li className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+                +{mentor.skills.length - 4} more
+              </li>
+            ) : null}
+          </ul>
+        ) : null}
+
+        {/* Industry chips */}
+        {mentor.industries.length > 0 ? (
+          <ul
+            role="list"
+            aria-label={`${mentor.name}'s industries`}
+            className="flex flex-wrap gap-1.5"
+          >
+            {mentor.industries.slice(0, 2).map((industry) => (
+              <li
+                key={industry}
+                className="inline-flex items-center gap-1 rounded-full bg-purple-50 px-2.5 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
+              >
+                <svg
+                  className="h-3 w-3"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6 6h.008v.008H6V6z"
+                  />
+                </svg>
+                {industry}
+              </li>
+            ))}
+            {mentor.industries.length > 2 ? (
+              <li className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+                +{mentor.industries.length - 2}
+              </li>
+            ) : null}
+          </ul>
+        ) : null}
+      </div>
+
+      {/* ── Footer / CTAs ────────────────────────────────────── */}
+      <div className="mt-auto flex items-center justify-between gap-3 border-t border-gray-100 bg-gray-50 px-6 py-4 dark:border-gray-800 dark:bg-gray-900/60">
+        <div className="flex flex-col">
+          <span className="text-xs leading-none text-gray-500 dark:text-gray-400">
+            per session
+          </span>
+          <span className="text-lg font-bold leading-snug text-gray-900 dark:text-white">
+            ${mentor.pricePerSession}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Link
+            href={profileHref}
+            className="text-sm font-semibold text-cyan-600 transition-colors hover:text-cyan-700 dark:text-cyan-400 dark:hover:text-cyan-300"
+            aria-label={`View profile of ${mentor.name}`}
+          >
+            Profile
+            <svg
+              className="ml-1 inline h-3.5 w-3.5"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2.5}
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+          </Link>
+
+          {unavailable ? (
+            <button
+              type="button"
+              disabled
+              aria-disabled="true"
+              className="cursor-not-allowed rounded-lg bg-gray-200 px-3.5 py-1.5 text-xs font-semibold text-gray-400 dark:bg-gray-800 dark:text-gray-500"
+            >
+              Unavailable
+            </button>
+          ) : (
+            <Link
+              href={`/book/${mentorSlug(mentor)}`}
+              className="rounded-lg bg-cyan-600 px-3.5 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-cyan-700 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2"
+              aria-label={`Book a session with ${mentor.name}`}
+            >
+              Book Session
+            </Link>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/app/(public)/mentors/components/FilterSidebar.tsx
+++ b/app/(public)/mentors/components/FilterSidebar.tsx
@@ -1,0 +1,381 @@
+'use client';
+
+import { useEffect, useRef, useSyncExternalStore } from 'react';
+import IndustryFilter from './IndustryFilter';
+import {
+  AVAILABILITY_OPTIONS,
+  EXPERIENCE_LEVELS,
+  PRICE_RANGES,
+  type AvailabilityStatus,
+  type ExperienceLevel,
+  type Mentor,
+  type PriceRangeId,
+} from '../data/mockMentors';
+
+// Tailwind's `lg` breakpoint lives at 1024 px. Below that the sidebar
+// behaves as a slide-in drawer; above it sits inline in the page grid.
+const LG_BREAKPOINT = '(min-width: 1024px)';
+
+/**
+ * SSR-safe media-query hook backed by useSyncExternalStore.
+ *
+ * - On the server `getServerSnapshot` returns `false` (responsive default).
+ * - On the client `subscribe` registers the change listener; `getSnapshot`
+ *   reads the current match.
+ * - This avoids the `react-hooks/set-state-in-effect` rule violation that
+ *   plagues a useState + useEffect pattern.
+ */
+function useMediaQuery(query: string): boolean {
+  return useSyncExternalStore(
+    (notify) => {
+      if (typeof window === 'undefined' || !window.matchMedia) {
+        return () => {};
+      }
+      const mql = window.matchMedia(query);
+      mql.addEventListener('change', notify);
+      return () => mql.removeEventListener('change', notify);
+    },
+    () => {
+      if (typeof window === 'undefined' || !window.matchMedia) return false;
+      return window.matchMedia(query).matches;
+    },
+    () => false,
+  );
+}
+
+export interface FilterState {
+  query: string;
+  selectedIndustries: string[];
+  selectedExperiences: ExperienceLevel[];
+  selectedAvailability: AvailabilityStatus[];
+  priceRangeId: PriceRangeId;
+}
+
+export interface FilterSidebarProps {
+  /** Whether the sidebar is visible on mobile (drawer mode). */
+  isOpen: boolean;
+  /** Close handler for mobile drawer. */
+  onClose: () => void;
+  /** All mentors available before this sidebar's filters apply — drives counts. */
+  mentors: Mentor[];
+  /** Current state. */
+  state: FilterState;
+  /** Reset everything to defaults. */
+  onReset: () => void;
+  // Per-filter setters — sidebar is a controlled component.
+  onToggleIndustry: (industry: string) => void;
+  onToggleExperience: (level: ExperienceLevel) => void;
+  onToggleAvailability: (status: AvailabilityStatus) => void;
+  onChangePriceRange: (id: PriceRangeId) => void;
+}
+
+const AVAILABILITY_LABELS: Record<AvailabilityStatus, string> = {
+  available: 'Available now',
+  busy: 'Limited slots',
+  'fully-booked': 'Waitlist only',
+};
+
+/**
+ * Reusable filter sidebar (Issue #458).
+ *
+ * - **Reusable.** Takes a controlled `FilterState` plus per-filter setters
+ *   so the parent can keep ownership of state and persistence (local
+ *   storage, URL params, global store, …) if/when that's desired.
+ * - **Responsive.** On `lg`+ it renders as a sticky aside. Below that
+ *   breakpoint the same component renders inside a fixed full-height
+ *   drawer with a backdrop and a focusable close button — driven by the
+ *   parent's `isOpen` flag.
+ */
+export default function FilterSidebar({
+  isOpen,
+  onClose,
+  mentors,
+  state,
+  onReset,
+  onToggleIndustry,
+  onToggleExperience,
+  onToggleAvailability,
+  onChangePriceRange,
+}: FilterSidebarProps) {
+  const isDesktop = useMediaQuery(LG_BREAKPOINT);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Close the drawer on Escape and lock body scroll while it's open on mobile.
+  useEffect(() => {
+    if (!isOpen || isDesktop) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen, isDesktop, onClose]);
+
+  // Move focus into the drawer on open so keyboard users land somewhere usable.
+  useEffect(() => {
+    if (!isOpen || isDesktop) return;
+    closeButtonRef.current?.focus();
+  }, [isOpen, isDesktop]);
+
+  const isFiltered =
+    state.selectedIndustries.length > 0 ||
+    state.selectedExperiences.length > 0 ||
+    state.selectedAvailability.length > 0 ||
+    state.priceRangeId !== 'any' ||
+    state.query.length > 0;
+
+  return (
+    <>
+      {/* Backdrop (mobile drawer only) */}
+      <div
+        aria-hidden="true"
+        onClick={onClose}
+        className={`fixed inset-0 z-40 bg-gray-900/60 backdrop-blur-sm transition-opacity duration-200 lg:hidden ${
+          isOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
+        }`}
+      />
+
+      {/* `inert` is set ONLY on mobile when the drawer is closed.
+          On desktop the sidebar is always rendered inline and accessible. */}
+      <aside
+        aria-label="Mentor filters"
+        inert={!isDesktop && !isOpen}
+        className={`
+          fixed inset-y-0 left-0 z-50 flex w-full max-w-sm flex-col gap-6 overflow-y-auto
+          border-r border-gray-200 bg-white p-6 shadow-2xl transition-transform duration-300
+          dark:border-gray-800 dark:bg-gray-950
+          lg:static lg:z-auto lg:max-w-none lg:translate-x-0 lg:overflow-visible lg:rounded-2xl
+          lg:border lg:shadow-sm
+          ${isOpen ? 'translate-x-0' : '-translate-x-full'}
+        `}
+      >
+        {/* Header */}
+        <header className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <svg
+              className="h-5 w-5 text-cyan-600 dark:text-cyan-400"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3 4.5h18M6 12h12M10 19.5h4"
+              />
+            </svg>
+            <h2 className="text-base font-bold text-gray-900 dark:text-white">
+              Filters
+            </h2>
+          </div>
+
+          <div className="flex items-center gap-2">
+            {isFiltered ? (
+              <button
+                type="button"
+                onClick={onReset}
+                className="rounded-md px-2 py-1 text-xs font-semibold text-cyan-600 transition-colors hover:bg-cyan-50 dark:text-cyan-400 dark:hover:bg-cyan-900/30"
+              >
+                Reset
+              </button>
+            ) : null}
+
+            {/* Close button only on mobile */}
+            <button
+              ref={closeButtonRef}
+              type="button"
+              onClick={onClose}
+              aria-label="Close filters"
+              className="rounded-md p-1.5 text-gray-500 transition-colors hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 lg:hidden"
+            >
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        </header>
+
+        {/* Industry */}
+        <IndustryFilter
+          mentors={mentors}
+          selected={state.selectedIndustries}
+          onToggle={onToggleIndustry}
+        />
+
+        <Divider />
+
+        {/* Experience Level (multi-select) */}
+        <FilterGroup title="Experience level">
+          <ul role="list" className="mt-2 space-y-1.5">
+            {EXPERIENCE_LEVELS.map((level) => {
+              const checked = state.selectedExperiences.includes(level);
+              return (
+                <li key={level}>
+                  <label className="flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1 text-sm text-gray-700 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800/60">
+                    <input
+                      type="checkbox"
+                      className="peer sr-only"
+                      checked={checked}
+                      onChange={() => onToggleExperience(level)}
+                      aria-label={`Filter by experience level ${level}`}
+                    />
+                    <span
+                      aria-hidden="true"
+                      className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-cyan-500 peer-focus-visible:ring-offset-1 dark:peer-focus-visible:ring-offset-cyan-900/40 ${
+                        checked
+                          ? 'border-cyan-500 bg-cyan-500 text-white'
+                          : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-900'
+                      }`}
+                    >
+                      {checked ? (
+                        <svg
+                          viewBox="0 0 12 12"
+                          className="h-3 w-3"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth={2.5}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M2 6.5l3 3 5-7"
+                          />
+                        </svg>
+                      ) : null}
+                    </span>
+                    <span>{level}</span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        </FilterGroup>
+
+        <Divider />
+
+        {/* Availability (multi-select) */}
+        <FilterGroup title="Availability">
+          <ul role="list" className="mt-2 space-y-1.5">
+            {AVAILABILITY_OPTIONS.map((status) => {
+              const checked = state.selectedAvailability.includes(status);
+              return (
+                <li key={status}>
+                  <label className="flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1 text-sm text-gray-700 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800/60">
+                    <input
+                      type="checkbox"
+                      className="peer sr-only"
+                      checked={checked}
+                      onChange={() => onToggleAvailability(status)}
+                      aria-label={`Filter by availability ${AVAILABILITY_LABELS[status]}`}
+                    />
+                    <span
+                      aria-hidden="true"
+                      className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-cyan-500 peer-focus-visible:ring-offset-1 dark:peer-focus-visible:ring-offset-cyan-900/40 ${
+                        checked
+                          ? 'border-cyan-500 bg-cyan-500 text-white'
+                          : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-900'
+                      }`}
+                    >
+                      {checked ? (
+                        <svg
+                          viewBox="0 0 12 12"
+                          className="h-3 w-3"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth={2.5}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M2 6.5l3 3 5-7"
+                          />
+                        </svg>
+                      ) : null}
+                    </span>
+                    <span>{AVAILABILITY_LABELS[status]}</span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        </FilterGroup>
+
+        <Divider />
+
+        {/* Price (radio) */}
+        <FilterGroup title="Price per session">
+          <ul role="list" className="mt-2 space-y-1.5">
+            {PRICE_RANGES.map((range) => {
+              const checked = state.priceRangeId === range.id;
+              return (
+                <li key={range.id}>
+                  <label className="flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1 text-sm text-gray-700 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800/60">
+                    <input
+                      type="radio"
+                      name="price-range"
+                      className="peer sr-only"
+                      checked={checked}
+                      onChange={() => onChangePriceRange(range.id)}
+                      aria-label={`Filter by ${range.label}`}
+                    />
+                    <span
+                      aria-hidden="true"
+                      className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-cyan-500 peer-focus-visible:ring-offset-1 dark:peer-focus-visible:ring-offset-cyan-900/40 ${
+                        checked
+                          ? 'border-cyan-500'
+                          : 'border-gray-300 dark:border-gray-600'
+                      }`}
+                    >
+                      {checked ? (
+                        <span className="h-2 w-2 rounded-full bg-cyan-500" />
+                      ) : null}
+                    </span>
+                    <span>{range.label}</span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        </FilterGroup>
+      </aside>
+    </>
+  );
+}
+
+function FilterGroup({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function Divider() {
+  return <hr className="border-0 border-t border-gray-100 dark:border-gray-800" />;
+}

--- a/app/(public)/mentors/components/IndustryFilter.tsx
+++ b/app/(public)/mentors/components/IndustryFilter.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { INDUSTRIES, type Mentor } from '../data/mockMentors';
+
+interface IndustryFilterProps {
+  /** All mentors available for filtering — used to compute counts. */
+  mentors: Mentor[];
+  /** Currently selected industry slugs (case-sensitive to INDUSTRIES). */
+  selected: string[];
+  /** Toggle an industry in or out of the selection. */
+  onToggle: (industry: string) => void;
+}
+
+/**
+ * Multi-select Industry filter (Issue #460).
+ *
+ * Renders a stack of labelled checkboxes — one per industry — with a count
+ * chip next to each label so users can see selection pressure before they
+ * commit. Multiple industries can be selected at once and matching uses
+ * logical OR (a mentor with any selected industry matches).
+ */
+export default function IndustryFilter({
+  mentors,
+  selected,
+  onToggle,
+}: IndustryFilterProps) {
+  // Counts are recomputed when the mentor list changes (i.e. when other
+  // filters narrow the candidate pool and we want to surface that
+  // "0 mentors in this industry" signal).
+  const counts = new Map<string, number>();
+  for (const mentor of mentors) {
+    for (const industry of mentor.industries) {
+      counts.set(industry, (counts.get(industry) ?? 0) + 1);
+    }
+  }
+
+  return (
+    <fieldset className="border-0 p-0 m-0">
+      <legend className="flex w-full items-center justify-between text-sm font-semibold text-gray-900 dark:text-white">
+        <span>Industry</span>
+        {selected.length > 0 ? (
+          <span
+            className="inline-flex items-center rounded-full bg-cyan-100 px-2 py-0.5 text-xs font-medium text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300"
+            aria-label={`${selected.length} industries selected`}
+          >
+            {selected.length} selected
+          </span>
+        ) : null}
+      </legend>
+
+      <ul role="list" className="mt-3 space-y-1">
+        {INDUSTRIES.map((industry) => {
+          const count = counts.get(industry) ?? 0;
+          const isSelected = selected.includes(industry);
+          return (
+            <li key={industry}>
+              <label
+                className={`flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-transparent px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800/60 ${
+                  isSelected
+                    ? 'border-cyan-200 bg-cyan-50/60 dark:border-cyan-800/60 dark:bg-cyan-900/20'
+                    : ''
+                }`}
+              >
+                <span className="flex items-center gap-2.5">
+                  <input
+                    type="checkbox"
+                    className="peer sr-only"
+                    checked={isSelected}
+                    onChange={() => onToggle(industry)}
+                    aria-label={`Filter by ${industry}`}
+                  />
+                  <span
+                    aria-hidden="true"
+                    className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-cyan-500 peer-focus-visible:ring-offset-1 ${
+                      isSelected
+                        ? 'border-cyan-500 bg-cyan-500 text-white'
+                        : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-900'
+                    }`}
+                  >
+                    {isSelected ? (
+                      <svg
+                        viewBox="0 0 12 12"
+                        className="h-3 w-3"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={2.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M2 6.5l3 3 5-7"
+                        />
+                      </svg>
+                    ) : null}
+                  </span>
+                  <span className="font-medium">{industry}</span>
+                </span>
+                <span className="text-xs tabular-nums text-gray-400 dark:text-gray-500">
+                  {count}
+                </span>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+    </fieldset>
+  );
+}

--- a/app/(public)/mentors/components/SearchBar.tsx
+++ b/app/(public)/mentors/components/SearchBar.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useId } from 'react';
+
+interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+/**
+ * Search input for the mentor discovery experience.
+ * Filters by name + headline + any of the mentor's skills (handled in the page).
+ * Uncontrolled-by-render — every keystroke updates instantly.
+ */
+export default function SearchBar({
+  value,
+  onChange,
+  placeholder = 'Search mentors by name, skill, or headline…',
+  className = '',
+}: SearchBarProps) {
+  const inputId = useId();
+
+  return (
+    <div className={`relative w-full ${className}`}>
+      <label htmlFor={inputId} className="sr-only">
+        Search mentors
+      </label>
+
+      {/* Search icon */}
+      <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
+        <svg
+          className="h-5 w-5 text-gray-400 dark:text-gray-500"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z"
+          />
+        </svg>
+      </div>
+
+      <input
+        id={inputId}
+        type="search"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        autoComplete="off"
+        spellCheck={false}
+        className="block w-full rounded-full border border-gray-200 bg-white py-3.5 pl-12 pr-12 text-sm text-gray-900 shadow-sm outline-none transition-all placeholder:text-gray-400 hover:border-gray-300 focus:border-cyan-500 focus:ring-2 focus:ring-cyan-500/20 md:text-base dark:border-gray-800 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
+      />
+
+      {value ? (
+        <button
+          type="button"
+          onClick={() => onChange('')}
+          aria-label="Clear search"
+          className="absolute inset-y-0 right-0 flex items-center pr-4 text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-300"
+        >
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/app/(public)/mentors/data/mockMentors.ts
+++ b/app/(public)/mentors/data/mockMentors.ts
@@ -1,0 +1,469 @@
+// Domain types & mock dataset for the Mentor Discovery experience.
+// Lives next to the (public)/mentors route group so the page and its
+// components can share data without polluting the global components/lib.
+
+export type ExperienceLevel = 'Junior' | 'Mid-Level' | 'Senior' | 'Executive';
+
+export type AvailabilityStatus = 'available' | 'busy' | 'fully-booked';
+
+export type SortOption = 'top-rated' | 'price-asc' | 'price-desc' | 'most-reviewed';
+
+export type PriceRangeId = 'any' | 'budget' | 'mid' | 'premium';
+
+export interface Mentor {
+  /** Stable identifier used for keys, URL params, and analytics. */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** A short professional tagline — drives the "Headline" search target. */
+  headline: string;
+  /** Long-form bio shown on hover, card body, and the profile page. */
+  bio: string;
+  /** Optional remote image URL for the avatar. Falls back to initials. */
+  avatarUrl?: string;
+  /** Skill stack surfaced as chips on the card and matched by search. */
+  skills: string[];
+  /** Domain / vertical tags used by the Industry filter. */
+  industries: string[];
+  experienceLevel: ExperienceLevel;
+  availability: AvailabilityStatus;
+  /** 0 – 5 inclusive, one decimal place. */
+  rating: number;
+  reviewCount: number;
+  /** Price in USD per 60-minute session. */
+  pricePerSession: number;
+  /** Years of professional experience driving the headline credibility. */
+  yearsExperience: number;
+}
+
+export const INDUSTRIES = [
+  'Technology',
+  'Finance',
+  'Healthcare',
+  'Education',
+  'Design',
+  'Marketing',
+  'Product',
+  'Data & AI',
+  'Entrepreneurship',
+  'Consulting',
+] as const;
+
+export type Industry = (typeof INDUSTRIES)[number];
+
+export const EXPERIENCE_LEVELS: ExperienceLevel[] = [
+  'Junior',
+  'Mid-Level',
+  'Senior',
+  'Executive',
+];
+
+export const AVAILABILITY_OPTIONS: AvailabilityStatus[] = [
+  'available',
+  'busy',
+  'fully-booked',
+];
+
+export const PRICE_RANGES: ReadonlyArray<{
+  id: PriceRangeId;
+  label: string;
+  min: number;
+  max: number;
+}> = [
+  { id: 'any', label: 'Any price', min: 0, max: Number.POSITIVE_INFINITY },
+  { id: 'budget', label: 'Under $50', min: 0, max: 49 },
+  { id: 'mid', label: '$50 – $99', min: 50, max: 99 },
+  { id: 'premium', label: '$100 & up', min: 100, max: Number.POSITIVE_INFINITY },
+];
+
+export const SORT_OPTIONS: ReadonlyArray<{ id: SortOption; label: string }> = [
+  { id: 'top-rated', label: 'Top rated' },
+  { id: 'most-reviewed', label: 'Most reviewed' },
+  { id: 'price-asc', label: 'Price: Low to high' },
+  { id: 'price-desc', label: 'Price: High to low' },
+];
+
+export const MENTORS: Mentor[] = [
+  {
+    id: 'amara-okonkwo',
+    name: 'Amara Okonkwo',
+    headline: 'Senior Software Engineer @ Stripe',
+    bio: 'Helps mid-level engineers land staff roles through system design coaching and behavioral interview prep. 12+ years at fintech scale-ups.',
+    skills: ['System Design', 'Go', 'TypeScript', 'Career Coaching', 'Interview Prep'],
+    industries: ['Technology', 'Finance'],
+    experienceLevel: 'Senior',
+    availability: 'available',
+    rating: 4.9,
+    reviewCount: 248,
+    pricePerSession: 120,
+    yearsExperience: 12,
+  },
+  {
+    id: 'jordan-park',
+    name: 'Jordan Park',
+    headline: 'Staff Product Designer @ Linear',
+    bio: 'Shipping product design systems used by half a million daily users. Loves teaching constraint-driven design and Figma workflows.',
+    skills: ['Product Design', 'Figma', 'Design Systems', 'UX Research'],
+    industries: ['Technology', 'Design', 'Product'],
+    experienceLevel: 'Senior',
+    availability: 'available',
+    rating: 4.8,
+    reviewCount: 192,
+    pricePerSession: 95,
+    yearsExperience: 9,
+  },
+  {
+    id: 'priya-shankar',
+    name: 'Priya Shankar',
+    headline: 'Engineering Manager @ Notion',
+    bio: 'From IC to manager coach. Mentors first-time engineering managers on giving feedback, running 1:1s, and planning teams.',
+    skills: ['Leadership', 'Engineering Management', 'Coaching', 'Career Coaching'],
+    industries: ['Technology', 'Product'],
+    experienceLevel: 'Executive',
+    availability: 'busy',
+    rating: 5.0,
+    reviewCount: 87,
+    pricePerSession: 180,
+    yearsExperience: 14,
+  },
+  {
+    id: 'david-okafor',
+    name: 'David Okafor',
+    headline: 'Founding Engineer @ Series A Healthtech',
+    bio: 'Ex-FHIR engineer turned founder. Coaches engineers transitioning from big tech into early-stage startups.',
+    skills: ['Node.js', 'Postgres', 'Healthcare Tech', 'Startup Strategy'],
+    industries: ['Technology', 'Healthcare'],
+    experienceLevel: 'Senior',
+    availability: 'available',
+    rating: 4.7,
+    reviewCount: 64,
+    pricePerSession: 110,
+    yearsExperience: 10,
+  },
+  {
+    id: 'lin-fu',
+    name: 'Lin Fu',
+    headline: 'Data Scientist @ Spotify',
+    bio: 'Recommender systems and experimentation. Helps analytics candidates prepare for take-home challenges and case studies.',
+    skills: ['Python', 'SQL', 'Machine Learning', 'A/B Testing'],
+    industries: ['Technology', 'Data & AI'],
+    experienceLevel: 'Mid-Level',
+    availability: 'available',
+    rating: 4.6,
+    reviewCount: 121,
+    pricePerSession: 75,
+    yearsExperience: 6,
+  },
+  {
+    id: 'samira-haddad',
+    name: 'Samira Haddad',
+    headline: 'Senior PM @ Shopify',
+    bio: 'Specializes in commerce platforms and 0-to-1 product discovery. Walks mentees through real PM interview loops.',
+    skills: ['Product Strategy', 'Roadmapping', 'Discovery', 'Stakeholder Management'],
+    industries: ['Product', 'Technology'],
+    experienceLevel: 'Senior',
+    availability: 'busy',
+    rating: 4.9,
+    reviewCount: 158,
+    pricePerSession: 105,
+    yearsExperience: 8,
+  },
+  {
+    id: 'mia-rodriguez',
+    name: 'Mia Rodriguez',
+    headline: 'Junior Frontend Engineer',
+    bio: 'Recently broke into tech after a coding bootcamp. Coaches career switchers on first 90 days and portfolio review.',
+    skills: ['React', 'CSS', 'JavaScript', 'Portfolio Review'],
+    industries: ['Technology', 'Education'],
+    experienceLevel: 'Junior',
+    availability: 'available',
+    rating: 4.5,
+    reviewCount: 41,
+    pricePerSession: 35,
+    yearsExperience: 2,
+  },
+  {
+    id: 'kenji-watanabe',
+    name: 'Kenji Watanabe',
+    headline: 'Founder & CEO @ Fintech AI Startup',
+    bio: 'Two-time founder. Mentors first-time founders on fundraising narrative, MVP scoping, and seed-deck storytelling.',
+    skills: ['Fundraising', 'Pitching', 'MVP Strategy', 'Leadership'],
+    industries: ['Entrepreneurship', 'Finance', 'Technology'],
+    experienceLevel: 'Executive',
+    availability: 'busy',
+    rating: 4.9,
+    reviewCount: 73,
+    pricePerSession: 220,
+    yearsExperience: 16,
+  },
+  {
+    id: 'elena-petrov',
+    name: 'Elena Petrov',
+    headline: 'UX Researcher @ Airbnb',
+    bio: 'Generative and evaluative research. Helps designers and PMs run their first diary studies and usability tests.',
+    skills: ['UX Research', 'Interviewing', 'Usability Testing', 'Synthesis'],
+    industries: ['Design', 'Product'],
+    experienceLevel: 'Mid-Level',
+    availability: 'available',
+    rating: 4.7,
+    reviewCount: 96,
+    pricePerSession: 70,
+    yearsExperience: 5,
+  },
+  {
+    id: 'marcus-lee',
+    name: 'Marcus Lee',
+    headline: 'Marketing Director @ HubSpot',
+    bio: 'Demand gen and lifecycle marketing. Coached 30+ marketers into senior and director-level roles.',
+    skills: ['Marketing Strategy', 'SEO', 'Content Strategy', 'Demand Gen'],
+    industries: ['Marketing', 'Technology'],
+    experienceLevel: 'Executive',
+    availability: 'available',
+    rating: 4.8,
+    reviewCount: 142,
+    pricePerSession: 140,
+    yearsExperience: 13,
+  },
+  {
+    id: 'aisha-rahman',
+    name: 'Aisha Rahman',
+    headline: 'Mid-Level Backend Engineer @ Cloudflare',
+    bio: 'Distributed systems enthusiast. Helps mid-level engineers deepen system design chops through case-based coaching.',
+    skills: ['Distributed Systems', 'Rust', 'Go', 'Kubernetes'],
+    industries: ['Technology'],
+    experienceLevel: 'Mid-Level',
+    availability: 'available',
+    rating: 4.6,
+    reviewCount: 78,
+    pricePerSession: 80,
+    yearsExperience: 6,
+  },
+  {
+    id: 'theo-klein',
+    name: 'Theo Klein',
+    headline: 'Senior Consultant @ McKinsey',
+    bio: 'Six years in management consulting. Helps candidates case-interview prep and transition into or out of consulting.',
+    skills: ['Case Interviewing', 'Strategy', 'Communication'],
+    industries: ['Consulting', 'Finance'],
+    experienceLevel: 'Senior',
+    availability: 'available',
+    rating: 4.7,
+    reviewCount: 109,
+    pricePerSession: 130,
+    yearsExperience: 7,
+  },
+  {
+    id: 'nina-castro',
+    name: 'Nina Castro',
+    headline: 'Senior ML Engineer @ Hugging Face',
+    bio: 'Open-source LLM fine-tuning. Walks mentees through technical portfolios and ML system design.',
+    skills: ['Python', 'PyTorch', 'LLMs', 'System Design'],
+    industries: ['Data & AI', 'Technology'],
+    experienceLevel: 'Senior',
+    availability: 'busy',
+    rating: 4.9,
+    reviewCount: 184,
+    pricePerSession: 150,
+    yearsExperience: 9,
+  },
+  {
+    id: 'ravi-mehta',
+    name: 'Ravi Mehta',
+    headline: 'Mid-Level Product Manager @ Atlassian',
+    bio: 'B2B SaaS product manager. Focus on growth loops, opportunity solution trees, and product analytics fluency.',
+    skills: ['Product Strategy', 'Analytics', 'B2B SaaS'],
+    industries: ['Product', 'Technology'],
+    experienceLevel: 'Mid-Level',
+    availability: 'available',
+    rating: 4.5,
+    reviewCount: 52,
+    pricePerSession: 65,
+    yearsExperience: 4,
+  },
+  {
+    id: 'ava-patel',
+    name: 'Ava Patel',
+    headline: 'Senior UX Designer @ Adobe',
+    bio: 'Specializes in design systems at scale. Helps designers ship components that survive beyond launch.',
+    skills: ['UX Design', 'Design Systems', 'Prototyping'],
+    industries: ['Design', 'Technology'],
+    experienceLevel: 'Senior',
+    availability: 'available',
+    rating: 4.7,
+    reviewCount: 88,
+    pricePerSession: 90,
+    yearsExperience: 8,
+  },
+  {
+    id: 'daniel-kim',
+    name: 'Daniel Kim',
+    headline: 'Frontend Engineer @ Vercel',
+    bio: 'Loves React, accessibility, and DX. Helps junior engineers grow into mid-level IC roles.',
+    skills: ['React', 'Accessibility', 'TypeScript'],
+    industries: ['Technology', 'Education'],
+    experienceLevel: 'Mid-Level',
+    availability: 'available',
+    rating: 4.8,
+    reviewCount: 134,
+    pricePerSession: 70,
+    yearsExperience: 5,
+  },
+  {
+    id: 'nia-thompson',
+    name: 'Nia Thompson',
+    headline: 'CTO @ Marketplace Startup',
+    bio: 'Engineering leadership at a two-sided marketplace. Coaches managers into senior IC or director roles.',
+    skills: ['Engineering Leadership', 'Architecture', 'Hiring'],
+    industries: ['Technology', 'Entrepreneurship'],
+    experienceLevel: 'Executive',
+    availability: 'busy',
+    rating: 5.0,
+    reviewCount: 61,
+    pricePerSession: 200,
+    yearsExperience: 15,
+  },
+  {
+    id: 'felix-morales',
+    name: 'Felix Morales',
+    headline: 'Junior Data Analyst @ Spotify',
+    bio: 'Bootcamp grad turned analyst. Coaches aspiring data analysts on SQL fluency and storytelling with numbers.',
+    skills: ['SQL', 'Tableau', 'Data Storytelling'],
+    industries: ['Data & AI', 'Education'],
+    experienceLevel: 'Junior',
+    availability: 'available',
+    rating: 4.4,
+    reviewCount: 28,
+    pricePerSession: 30,
+    yearsExperience: 1,
+  },
+  {
+    id: 'olu-adebayo',
+    name: 'Olu Adebayo',
+    headline: 'Senior Investment Banker @ Goldman Sachs',
+    bio: 'Career switcher mentor. Helps professionals move from consulting / banking into product, ops, or tech.',
+    skills: ['Finance', 'Career Switching', 'Networking'],
+    industries: ['Finance', 'Consulting'],
+    experienceLevel: 'Senior',
+    availability: 'available',
+    rating: 4.6,
+    reviewCount: 71,
+    pricePerSession: 160,
+    yearsExperience: 9,
+  },
+  {
+    id: 'clara-novak',
+    name: 'Clara Novak',
+    headline: 'Healthcare PM @ Mayo Digital',
+    bio: 'Digital health product management. Mentors PM candidates targeting healthcare regulated environments.',
+    skills: ['Healthcare Tech', 'Compliance', 'Discovery'],
+    industries: ['Healthcare', 'Product'],
+    experienceLevel: 'Senior',
+    availability: 'available',
+    rating: 4.7,
+    reviewCount: 83,
+    pricePerSession: 115,
+    yearsExperience: 10,
+  },
+  {
+    id: 'isaac-bell',
+    name: 'Isaac Bell',
+    headline: 'Executive Coach & Former VP Eng',
+    bio: 'Coaches senior leaders into executive roles. Focus on executive presence, board communication, and promotion packets.',
+    skills: ['Executive Coaching', 'Leadership', 'Promotion Strategy'],
+    industries: ['Consulting', 'Education'],
+    experienceLevel: 'Executive',
+    availability: 'fully-booked',
+    rating: 4.9,
+    reviewCount: 119,
+    pricePerSession: 250,
+    yearsExperience: 20,
+  },
+  {
+    id: 'rita-singh',
+    name: 'Rita Singh',
+    headline: 'Senior Content Strategist @ Buffer',
+    bio: 'Brand-led content strategy. Mentees land content-lead roles within 6 months of working with me.',
+    skills: ['Content Strategy', 'Brand Voice', 'Editorial Planning'],
+    industries: ['Marketing'],
+    experienceLevel: 'Senior',
+    availability: 'available',
+    rating: 4.7,
+    reviewCount: 75,
+    pricePerSession: 88,
+    yearsExperience: 8,
+  },
+  {
+    id: 'omar-zaher',
+    name: 'Omar Zaher',
+    headline: 'Mid-Level iOS Engineer',
+    bio: 'Swift and SwiftUI specialist. Helps mobile engineers level up by reviewing real-world app code together.',
+    skills: ['Swift', 'SwiftUI', 'iOS Architecture'],
+    industries: ['Technology'],
+    experienceLevel: 'Mid-Level',
+    availability: 'busy',
+    rating: 4.6,
+    reviewCount: 47,
+    pricePerSession: 60,
+    yearsExperience: 4,
+  },
+  {
+    id: 'isabella-romano',
+    name: 'Isabella Romano',
+    headline: 'Senior Brand Designer @ Glossier',
+    bio: 'Identity, packaging, and brand systems. Coaches designers on portfolio storytelling and case-study presentation.',
+    skills: ['Brand Design', 'Typography', 'Portfolio Review'],
+    industries: ['Design', 'Marketing'],
+    experienceLevel: 'Senior',
+    availability: 'available',
+    rating: 4.8,
+    reviewCount: 102,
+    pricePerSession: 100,
+    yearsExperience: 11,
+  },
+];
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers used by the discovery page. Keeping them co-located so the page
+// stays focused on orchestration.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Stable slug for URL routing. Falls back to id. */
+export function mentorSlug(mentor: Pick<Mentor, 'id' | 'name'>): string {
+  return (
+    mentor.id ||
+    mentor.name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '')
+  );
+}
+
+/** Counts mentors per industry so checkboxes can show availability. */
+export function countByIndustry(
+  mentors: Mentor[],
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const m of mentors) {
+    for (const industry of m.industries) {
+      counts[industry] = (counts[industry] ?? 0) + 1;
+    }
+  }
+  return counts;
+}
+
+/**
+ * Case-insensitive match against name, headline, and every skill token.
+ * Returns true when the query is empty (so the caller should treat that as
+ * "every mentor matches" via a separate check).
+ */
+export function matchesQuery(mentor: Mentor, query: string): boolean {
+  if (!query) return true;
+  const needle = query.trim().toLowerCase();
+  if (!needle) return true;
+  if (mentor.name.toLowerCase().includes(needle)) return true;
+  if (mentor.headline.toLowerCase().includes(needle)) return true;
+  for (const skill of mentor.skills) {
+    if (skill.toLowerCase().includes(needle)) return true;
+  }
+  return false;
+}

--- a/app/(public)/mentors/page.tsx
+++ b/app/(public)/mentors/page.tsx
@@ -1,0 +1,450 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import SearchBar from './components/SearchBar';
+import FilterSidebar, { type FilterState } from './components/FilterSidebar';
+import DiscoveryMentorCard from './components/DiscoveryMentorCard';
+import {
+  MENTORS,
+  PRICE_RANGES,
+  SORT_OPTIONS,
+  matchesQuery,
+  type AvailabilityStatus,
+  type ExperienceLevel,
+  type PriceRangeId,
+  type SortOption,
+} from './data/mockMentors';
+
+const DEFAULT_STATE: FilterState = {
+  query: '',
+  selectedIndustries: [],
+  selectedExperiences: [],
+  selectedAvailability: [],
+  priceRangeId: 'any',
+};
+
+/**
+ * Mentor Discovery page.
+ *
+ * Closes GitHub issues:
+ *  - #458 Create Filter Sidebar Component (reusable, responsive)
+ *  - #460 Add Industry Filter (multi-select industries)
+ *  - #457 Implement Mentor Search Functionality (name / skills / headline)
+ *
+ * State is local since the dataset is small and client-side filtering is
+ * instantaneous. URL-shareable state can be layered on later via
+ * `useRouter().replace` without changing these components.
+ */
+export default function MentorsDiscoveryPage() {
+  const [state, setState] = useState<FilterState>(DEFAULT_STATE);
+  const [sortBy, setSortBy] = useState<SortOption>('top-rated');
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // The mentor list is static for now — kept as a constant so swapping it
+  // for a fetch() later is a one-line change.
+  const filtered = useMemo(() => {
+    const range = PRICE_RANGES.find((r) => r.id === state.priceRangeId) ??
+      PRICE_RANGES[0];
+
+    const matches = MENTORS.filter((mentor) => {
+      // 1. Search by name / headline / skills (Issue #457)
+      if (!matchesQuery(mentor, state.query)) return false;
+
+      // 2. Multi-select industry — logical OR (Issue #460)
+      if (
+        state.selectedIndustries.length > 0 &&
+        !mentor.industries.some((i) => state.selectedIndustries.includes(i))
+      ) {
+        return false;
+      }
+
+      // 3. Multi-select experience — logical OR
+      if (
+        state.selectedExperiences.length > 0 &&
+        !state.selectedExperiences.includes(mentor.experienceLevel)
+      ) {
+        return false;
+      }
+
+      // 4. Multi-select availability — logical OR
+      if (
+        state.selectedAvailability.length > 0 &&
+        !state.selectedAvailability.includes(mentor.availability)
+      ) {
+        return false;
+      }
+
+      // 5. Price range
+      if (mentor.pricePerSession < range.min) return false;
+      if (mentor.pricePerSession > range.max) return false;
+
+      return true;
+    });
+
+    // Sort
+    const sorted = [...matches];
+    switch (sortBy) {
+      case 'price-asc':
+        sorted.sort((a, b) => a.pricePerSession - b.pricePerSession);
+        break;
+      case 'price-desc':
+        sorted.sort((a, b) => b.pricePerSession - a.pricePerSession);
+        break;
+      case 'most-reviewed':
+        sorted.sort((a, b) => b.reviewCount - a.reviewCount);
+        break;
+      case 'top-rated':
+      default:
+        sorted.sort(
+          (a, b) =>
+            b.rating - a.rating || b.reviewCount - a.reviewCount,
+        );
+        break;
+    }
+    return sorted;
+  }, [state, sortBy]);
+
+  // ── Handlers ─────────────────────────────────────────────────────
+  const toggleIndustry = (industry: string) =>
+    setState((prev) => ({
+      ...prev,
+      selectedIndustries: prev.selectedIndustries.includes(industry)
+        ? prev.selectedIndustries.filter((i) => i !== industry)
+        : [...prev.selectedIndustries, industry],
+    }));
+
+  const toggleExperience = (level: ExperienceLevel) =>
+    setState((prev) => ({
+      ...prev,
+      selectedExperiences: prev.selectedExperiences.includes(level)
+        ? prev.selectedExperiences.filter((l) => l !== level)
+        : [...prev.selectedExperiences, level],
+    }));
+
+  const toggleAvailability = (status: AvailabilityStatus) =>
+    setState((prev) => ({
+      ...prev,
+      selectedAvailability: prev.selectedAvailability.includes(status)
+        ? prev.selectedAvailability.filter((s) => s !== status)
+        : [...prev.selectedAvailability, status],
+    }));
+
+  const changePriceRange = (id: PriceRangeId) =>
+    setState((prev) => ({ ...prev, priceRangeId: id }));
+
+  const resetFilters = () => setState(DEFAULT_STATE);
+
+  const activeFilterCount =
+    state.selectedIndustries.length +
+    state.selectedExperiences.length +
+    state.selectedAvailability.length +
+    (state.priceRangeId !== 'any' ? 1 : 0);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+      {/* ── Hero ───────────────────────────────────────────────── */}
+      <section
+        aria-labelledby="discovery-hero-heading"
+        className="relative overflow-hidden bg-gradient-to-br from-cyan-700 via-cyan-600 to-blue-700 px-4 py-12 text-white md:py-16"
+      >
+        {/* Decorative background orbs */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute -right-16 -top-16 h-64 w-64 rounded-full bg-white/10 blur-3xl"
+        />
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute -bottom-24 -left-12 h-72 w-72 rounded-full bg-blue-400/30 blur-3xl"
+        />
+
+        <div className="relative mx-auto max-w-screen-xl">
+          <span className="inline-flex items-center gap-2 rounded-full bg-white/15 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-white ring-1 ring-white/20 backdrop-blur">
+            <svg
+              className="h-3.5 w-3.5"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z"
+              />
+            </svg>
+            Discover Your Next Mentor
+          </span>
+          <h1
+            id="discovery-hero-heading"
+            className="mt-3 text-3xl font-extrabold leading-tight md:text-5xl"
+          >
+            Find a mentor that fits your career path
+          </h1>
+          <p className="mt-3 max-w-2xl text-base leading-relaxed text-cyan-50 md:text-lg">
+            Search by skill, headline, or industry. Filter by availability,
+            experience, and price to land on the right match — instantly.
+          </p>
+
+          <div className="mt-6 max-w-2xl">
+            <SearchBar
+              value={state.query}
+              onChange={(query) =>
+                setState((prev) => ({ ...prev, query }))
+              }
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* ── Toolbar / sort + mobile filter trigger ─────────────── */}
+      <section className="border-b border-gray-200 bg-white px-4 py-4 dark:border-gray-800 dark:bg-gray-900">
+        <div className="mx-auto flex max-w-screen-xl flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            {/* Mobile filters button */}
+            <button
+              type="button"
+              onClick={() => setDrawerOpen(true)}
+              className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3.5 py-2 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 lg:hidden"
+              aria-label="Open filters"
+            >
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3 4.5h18M6 12h12M10 19.5h4"
+                />
+              </svg>
+              Filters
+              {activeFilterCount > 0 ? (
+                <span className="ml-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-cyan-600 px-1.5 text-xs font-semibold text-white">
+                  {activeFilterCount}
+                </span>
+              ) : null}
+            </button>
+
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              <span className="font-semibold text-gray-900 dark:text-white">
+                {filtered.length}
+              </span>{' '}
+              {filtered.length === 1 ? 'mentor' : 'mentors'} ·{' '}
+              <span className="text-gray-500 dark:text-gray-500">
+                {MENTORS.length} total
+              </span>
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <label
+              htmlFor="sort-by"
+              className="text-sm font-medium text-gray-600 dark:text-gray-400"
+            >
+              Sort by
+            </label>
+            <div className="relative">
+              <select
+                id="sort-by"
+                value={sortBy}
+                onChange={(event) =>
+                  setSortBy(event.target.value as SortOption)
+                }
+                className="appearance-none rounded-lg border border-gray-200 bg-white py-2 pl-3 pr-9 text-sm font-medium text-gray-700 transition-colors hover:border-gray-300 focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/20 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300"
+              >
+                {SORT_OPTIONS.map((opt) => (
+                  <option key={opt.id} value={opt.id}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+              <svg
+                className="pointer-events-none absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        {/* Active filter chips */}
+        {activeFilterCount > 0 ? (
+          <div className="mx-auto mt-3 flex max-w-screen-xl flex-wrap gap-2">
+            <span className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Active:
+            </span>
+            {state.selectedIndustries.map((i) => (
+              <Chip
+                key={`i-${i}`}
+                label={`Industry: ${i}`}
+                onRemove={() => toggleIndustry(i)}
+              />
+            ))}
+            {state.selectedExperiences.map((l) => (
+              <Chip
+                key={`l-${l}`}
+                label={`Experience: ${l}`}
+                onRemove={() => toggleExperience(l)}
+              />
+            ))}
+            {state.selectedAvailability.map((s) => (
+              <Chip
+                key={`s-${s}`}
+                label={`Availability: ${s.replace('-', ' ')}`}
+                onRemove={() => toggleAvailability(s)}
+              />
+            ))}
+            {state.priceRangeId !== 'any' ? (
+              <Chip
+                key="price"
+                label={
+                  'Price: ' +
+                  (PRICE_RANGES.find((r) => r.id === state.priceRangeId)
+                    ?.label ?? '')
+                }
+                onRemove={() => changePriceRange('any')}
+              />
+            ) : null}
+            {state.query ? (
+              <Chip
+                key="query"
+                label={`Search: “${state.query}”`}
+                onRemove={() =>
+                  setState((prev) => ({ ...prev, query: '' }))
+                }
+              />
+            ) : null}
+
+            <button
+              type="button"
+              onClick={resetFilters}
+              className="rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-700 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              Clear all
+            </button>
+          </div>
+        ) : null}
+      </section>
+
+      {/* ── Main grid ─────────────────────────────────────────── */}
+      <section className="mx-auto max-w-screen-xl px-4 py-8">
+        <div className="grid gap-6 lg:grid-cols-[18rem,1fr]">
+          <FilterSidebar
+            isOpen={drawerOpen}
+            onClose={() => setDrawerOpen(false)}
+            mentors={MENTORS}
+            state={state}
+            onReset={resetFilters}
+            onToggleIndustry={toggleIndustry}
+            onToggleExperience={toggleExperience}
+            onToggleAvailability={toggleAvailability}
+            onChangePriceRange={changePriceRange}
+          />
+
+          {filtered.length > 0 ? (
+            <ul
+              role="list"
+              aria-label="Mentor results"
+              className="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-3"
+            >
+              {filtered.map((mentor) => (
+                <li key={mentor.id}>
+                  <DiscoveryMentorCard mentor={mentor} />
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <EmptyState onReset={resetFilters} hasQuery={state.query.length > 0} />
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function Chip({ label, onRemove }: { label: string; onRemove: () => void }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-cyan-50 py-1 pl-3 pr-1 text-xs font-medium text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300">
+      {label}
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove filter ${label}`}
+        className="flex h-5 w-5 items-center justify-center rounded-full text-cyan-700 transition-colors hover:bg-cyan-200 dark:text-cyan-300 dark:hover:bg-cyan-800"
+      >
+        <svg
+          className="h-3 w-3"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2.5}
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M6 18L18 6M6 6l12 12"
+          />
+        </svg>
+      </button>
+    </span>
+  );
+}
+
+function EmptyState({
+  onReset,
+  hasQuery,
+}: {
+  onReset: () => void;
+  hasQuery: boolean;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-gray-200 bg-white px-6 py-16 text-center dark:border-gray-800 dark:bg-gray-900">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-cyan-50 text-cyan-600 dark:bg-cyan-900/40 dark:text-cyan-300">
+        <svg
+          className="h-8 w-8"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z"
+          />
+        </svg>
+      </div>
+      <h3 className="mt-4 text-lg font-bold text-gray-900 dark:text-white">
+        No mentors match your filters
+      </h3>
+      <p className="mt-1 max-w-sm text-sm text-gray-600 dark:text-gray-400">
+        {hasQuery
+          ? 'Try a different search term or broaden your filters to see more results.'
+          : 'Try removing a filter to widen your search.'}
+      </p>
+      <button
+        type="button"
+        onClick={onReset}
+        className="mt-4 rounded-lg bg-cyan-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-cyan-700 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2"
+      >
+        Clear all filters
+      </button>
+    </div>
+  );
+}

--- a/components/navigation/Footer.tsx
+++ b/components/navigation/Footer.tsx
@@ -45,7 +45,7 @@ export default function Footer() {
             </h3>
             <ul className="space-y-2.5">
               <li>
-                <Link href="/discover-mentors" className="text-sm text-gray-600 hover:text-cyan-600 dark:text-gray-400 dark:hover:text-cyan-400 transition-colors">
+                <Link href="/mentors" className="text-sm text-gray-600 hover:text-cyan-600 dark:text-gray-400 dark:hover:text-cyan-400 transition-colors">
                   Discover Mentors
                 </Link>
               </li>

--- a/components/navigation/Navbar.tsx
+++ b/components/navigation/Navbar.tsx
@@ -6,7 +6,7 @@ import { usePathname } from 'next/navigation';
 
 const navLinks = [
   { label: 'Home', href: '/' },
-  { label: 'Discover Mentors', href: '/discover-mentors' },
+  { label: 'Discover Mentors', href: '/mentors' },
   { label: 'Learning Resources', href: '/resources' },
   { label: 'How It Works', href: '/how-it-works' },
   { label: 'Pricing', href: '/pricing' },


### PR DESCRIPTION
Implements the public Mentor Discovery experience and closes three tracking issues:

Closes #458 Filter Sidebar Component
Closes #460 Industry Filter
Closes #457 Mentor Search

## Routes / behaviour

- New `/mentors` route: full discovery UX (search by name/headline/skills, multi-select Industry + Experience Level + Availability, price radios, four sort modes, active filter chips with remove buttons, mobile drawer with backdrop + Escape + body scroll lock + auto-focus, empty-state fallback).
- Minimal `/mentors/[mentorId]` server component: async `params` per the Next 16 contract, `generateStaticParams` enumerated from the mock dataset. Book a session CTA is a real disabled button when fully-booked.
- Typed in-memory dataset of 24 mentors with helpers (`mentorSlug`, `matchesQuery`, `countByIndustry`). Swap for a real fetch is a one-line change.

## Nav updates

- Navbar + Footer Discover Mentors now point to `/mentors` instead of `/discover-mentors`.

## Why a local `DiscoveryMentorCard`

The global `components/MentorCard.tsx` has duplicate exports, duplicate interfaces, and truncated braces — it fails a strict compile. Cleanup PR for the global card to follow separately; the local copy in this PR is deliberate.

## Out of scope (deliberate exclusions)

- Real `/book/[slug]` route (cards and the profile link there; the route does not exist yet).
- URL-shareable filter state via `useRouter().replace`.
- Cleanup of `components/MentorCard.tsx`.
- `/discover-mentors` redirect for the old URL.