### PR TITLE
feat(discover): add Mentor Discovery page with two-column layout and expertise filter

### DIFF
--- a/app/(public)/discover-mentors/MentorDiscoveryView.tsx
+++ b/app/(public)/discover-mentors/MentorDiscoveryView.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import ExpertiseFilter from '@/components/mentors/ExpertiseFilter';
+import DiscoveryMentorCard from '@/components/mentors/DiscoveryMentorCard';
+import {
+  EXPERTISE_OPTIONS,
+  type Expertise,
+  type Mentor,
+} from '@/components/mentors/data';
+
+type SortOption = 'rating-desc' | 'price-asc' | 'price-desc' | 'experience-desc';
+
+const SORT_OPTIONS: ReadonlyArray<{ value: SortOption; label: string }> = [
+  { value: 'rating-desc', label: 'Highest rated' },
+  { value: 'price-asc', label: 'Price: low to high' },
+  { value: 'price-desc', label: 'Price: high to low' },
+  { value: 'experience-desc', label: 'Most experienced' },
+];
+
+interface MentorDiscoveryViewProps {
+  mentors: Mentor[];
+}
+
+export default function MentorDiscoveryView({ mentors }: MentorDiscoveryViewProps) {
+  const [selectedExpertise, setSelectedExpertise] = useState<Expertise[]>([]);
+  const [sort, setSort] = useState<SortOption>('rating-desc');
+
+  const toggleExpertise = (expertise: Expertise) => {
+    setSelectedExpertise((prev) =>
+      prev.includes(expertise) ? prev.filter((e) => e !== expertise) : [...prev, expertise],
+    );
+  };
+
+  const clearExpertise = () => setSelectedExpertise([]);
+
+  /** Total mentors per expertise, regardless of currently selected filters. */
+  const counts = useMemo<Record<Expertise, number>>(() => {
+    const initial = {} as Record<Expertise, number>;
+    for (const exp of EXPERTISE_OPTIONS) initial[exp] = 0;
+    for (const mentor of mentors) {
+      for (const exp of mentor.expertise) {
+        initial[exp] += 1;
+      }
+    }
+    return initial;
+  }, [mentors]);
+
+  const filteredMentors = useMemo<Mentor[]>(() => {
+    const matched =
+      selectedExpertise.length === 0
+        ? mentors
+        : mentors.filter((mentor) =>
+            mentor.expertise.some((e) => selectedExpertise.includes(e)),
+          );
+
+    const sorted = [...matched];
+    sorted.sort((a, b) => {
+      switch (sort) {
+        case 'rating-desc':
+          return b.rating - a.rating;
+        case 'price-asc':
+          return a.pricePerSession - b.pricePerSession;
+        case 'price-desc':
+          return b.pricePerSession - a.pricePerSession;
+        case 'experience-desc':
+          return b.experienceYears - a.experienceYears;
+        default:
+          return 0;
+      }
+    });
+    return sorted;
+  }, [mentors, selectedExpertise, sort]);
+
+  const hasFilters = selectedExpertise.length > 0;
+  const resultNoun = filteredMentors.length === 1 ? 'mentor' : 'mentors';
+
+  return (
+    <div className="max-w-screen-xl mx-auto px-4 pb-16">
+      <div className="flex flex-col gap-8 md:flex-row md:gap-8">
+        {/* Sidebar */}
+        <aside
+          aria-label="Mentor filters"
+          className="w-full md:w-64 lg:w-72 shrink-0"
+        >
+          <div className="md:sticky md:top-28">
+            <div className="rounded-2xl bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-700/80 p-5 shadow-sm">
+              <div className="mb-5 flex items-center justify-between">
+                <h2 className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                  Filters
+                </h2>
+                {hasFilters && (
+                  <button
+                    type="button"
+                    onClick={clearExpertise}
+                    className="text-xs font-semibold text-cyan-600 hover:text-cyan-700 dark:text-cyan-400 dark:hover:text-cyan-300 focus:outline-none focus:underline"
+                    aria-label="Clear all mentor filters"
+                  >
+                    Clear all
+                  </button>
+                )}
+              </div>
+              <ExpertiseFilter
+                selected={selectedExpertise}
+                counts={counts}
+                onToggle={toggleExpertise}
+                onClear={clearExpertise}
+              />
+            </div>
+          </div>
+        </aside>
+
+        {/* Listing */}
+        <section
+          aria-label="Mentor results"
+          className="flex-1 min-w-0"
+        >
+          <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p
+              className="text-sm text-gray-600 dark:text-gray-400"
+              aria-live="polite"
+            >
+              <span className="font-semibold text-gray-900 dark:text-white tabular-nums">
+                {filteredMentors.length}
+              </span>{' '}
+              {resultNoun}
+              {hasFilters ? ' match your filters' : ' available'}
+            </p>
+
+            <div className="flex items-center gap-2">
+              <label
+                htmlFor="sort-select"
+                className="text-sm font-medium text-gray-600 dark:text-gray-400 whitespace-nowrap"
+              >
+                Sort by
+              </label>
+              <div className="relative">
+                <select
+                  id="sort-select"
+                  value={sort}
+                  onChange={(event) => setSort(event.target.value as SortOption)}
+                  className="appearance-none rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 pl-3 pr-9 py-2 text-sm font-medium text-gray-900 dark:text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition-colors"
+                >
+                  {SORT_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                <svg
+                  className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 dark:text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                </svg>
+              </div>
+            </div>
+          </div>
+
+          {filteredMentors.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 py-16 px-6 text-center">
+              <div className="w-12 h-12 rounded-full bg-cyan-50 dark:bg-cyan-900/30 flex items-center justify-center text-cyan-600 dark:text-cyan-400">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth="1.8"
+                  stroke="currentColor"
+                  className="w-6 h-6"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M21 21l-4.35-4.35m1.85-5.4a7 7 0 11-14 0 7 7 0 0114 0z"
+                  />
+                </svg>
+              </div>
+              <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+                No mentors match your filters
+              </h3>
+              <p className="text-sm text-gray-500 dark:text-gray-400 max-w-sm">
+                Try removing a tag or two from the expertise filter to broaden your search.
+              </p>
+              <button
+                type="button"
+                onClick={clearExpertise}
+                className="mt-2 text-sm font-semibold text-cyan-600 hover:text-cyan-700 dark:text-cyan-400 dark:hover:text-cyan-300 focus:outline-none focus:underline"
+              >
+                Clear expertise filters
+              </button>
+            </div>
+          ) : (
+            <ul
+              role="list"
+              className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6"
+            >
+              {filteredMentors.map((mentor) => (
+                <li key={mentor.id} className="h-full">
+                  <DiscoveryMentorCard mentor={mentor} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+

--- a/app/(public)/discover-mentors/page.tsx
+++ b/app/(public)/discover-mentors/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next';
+import MentorDiscoveryView from './MentorDiscoveryView';
+import { MOCK_MENTORS } from '@/components/mentors/data';
+
+export const metadata: Metadata = {
+  title: 'Discover Mentors · SkillSync',
+  description:
+    'Browse vetted mentors by expertise, availability, and price. Find the right mentor for your goals on SkillSync.',
+};
+
+export default function DiscoverMentorsPage() {
+  return (
+    <div className="bg-slate-50 dark:bg-gray-950 min-h-screen transition-colors">
+      {/* Header / hero strip */}
+      <section
+        aria-labelledby="discover-mentors-heading"
+        className="bg-gradient-to-br from-cyan-700 via-cyan-600 to-blue-700 text-white"
+      >
+        <div className="max-w-screen-xl mx-auto px-4 py-12 sm:py-16">
+          <p className="text-xs font-bold uppercase tracking-[0.2em] text-cyan-100/80">
+            Mentor Discovery
+          </p>
+          <h1
+            id="discover-mentors-heading"
+            className="mt-3 text-3xl sm:text-4xl lg:text-5xl font-extrabold tracking-tight"
+          >
+            Find a mentor who fits your goals
+          </h1>
+          <p className="mt-4 text-base sm:text-lg text-cyan-50/90 max-w-2xl leading-relaxed">
+            Browse {MOCK_MENTORS.length}+ vetted mentors across frontend, backend, design,
+            product, and more. Use the filters on the left to narrow down by expertise
+            area — results update instantly.
+          </p>
+        </div>
+      </section>
+
+      {/* Two-column layout: filter sidebar + mentor grid */}
+      <MentorDiscoveryView mentors={MOCK_MENTORS} />
+    </div>
+  );
+}

--- a/components/mentors/DiscoveryMentorCard.tsx
+++ b/components/mentors/DiscoveryMentorCard.tsx
@@ -1,0 +1,182 @@
+import Link from 'next/link';
+import StarRating from '@/components/ui/StarRating';
+import MentorAvailabilityBadge from '@/components/MentorAvailabilityBadge';
+import type { Mentor } from './data';
+
+interface DiscoveryMentorCardProps {
+  mentor: Mentor;
+}
+
+/**
+ * Deterministic gradient palette so avatars look consistent across renders.
+ * Index is derived from the mentor's name so the gradient never flickers.
+ */
+const AVATAR_GRADIENTS = [
+  'from-cyan-500 to-blue-600',
+  'from-purple-500 to-indigo-600',
+  'from-emerald-500 to-teal-600',
+  'from-pink-500 to-rose-600',
+  'from-amber-500 to-orange-600',
+  'from-indigo-500 to-sky-600',
+] as const;
+
+function initialsFor(name: string): string {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .map((part) => part[0] ?? '')
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+function gradientFor(name: string): string {
+  // Sum char codes so similar names don't accidentally collide visually.
+  const hash = [...name].reduce((acc, ch) => acc + ch.charCodeAt(0), 0);
+  const idx = hash % AVATAR_GRADIENTS.length;
+  return AVATAR_GRADIENTS[idx];
+}
+
+function slugFor(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, '-');
+}
+
+export default function DiscoveryMentorCard({ mentor }: DiscoveryMentorCardProps) {
+  const initials = initialsFor(mentor.name);
+  const gradient = gradientFor(mentor.name);
+  const profileHref = `/mentors/${slugFor(mentor.name)}`;
+  const isFullyBooked = mentor.availability === 'fully-booked';
+
+  return (
+    <article className="relative h-full flex flex-col bg-white border border-gray-100 rounded-2xl shadow-sm hover:shadow-md transition-all duration-300 dark:bg-gray-800 dark:border-gray-700/80 group overflow-hidden">
+      <div className="p-6 flex flex-col gap-4 grow">
+        {/* Avatar + availability badge */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="relative shrink-0">
+            {mentor.avatarUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element -- dynamic avatar URLs may come from external CDNs without remotePatterns configured.
+              <img
+                src={mentor.avatarUrl}
+                alt={`Photo of ${mentor.name}`}
+                className="w-14 h-14 rounded-2xl object-cover shadow-md group-hover:scale-105 transition-transform duration-300"
+              />
+            ) : (
+              <div
+                className={`w-14 h-14 rounded-2xl bg-gradient-to-br ${gradient} flex items-center justify-center text-white text-lg font-bold shadow-md group-hover:scale-105 transition-transform duration-300`}
+                aria-hidden="true"
+              >
+                {initials}
+              </div>
+            )}
+          </div>
+          <MentorAvailabilityBadge status={mentor.availability} />
+        </div>
+
+        {/* Identity */}
+        <div className="min-w-0">
+          <h3 className="text-lg font-bold text-gray-900 dark:text-white group-hover:text-cyan-600 dark:group-hover:text-cyan-400 transition-colors leading-tight">
+            {mentor.name}
+          </h3>
+          <p className="text-sm font-semibold text-cyan-600 dark:text-cyan-400 mt-0.5 truncate">
+            {mentor.title}
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            {mentor.company} · {mentor.experienceYears}+ yrs experience
+          </p>
+        </div>
+
+        {/* Rating */}
+        <div className="flex items-center gap-2 flex-wrap" aria-label={`Rating: ${mentor.rating} out of 5`}>
+          <StarRating rating={mentor.rating} size="sm" />
+          <span className="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
+            {mentor.rating.toFixed(1)}
+          </span>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            ({mentor.reviewCount.toLocaleString()} reviews)
+          </span>
+        </div>
+
+        {/* Bio */}
+        <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed line-clamp-3">
+          {mentor.bio}
+        </p>
+
+        {/* Expertise chips (a compact view) */}
+        {mentor.expertise.length > 0 && (
+          <div className="flex flex-wrap gap-1.5" aria-label="Areas of expertise">
+            {mentor.expertise.slice(0, 2).map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center rounded-full bg-cyan-50 dark:bg-cyan-900/30 px-2.5 py-0.5 text-xs font-medium text-cyan-700 dark:text-cyan-300"
+              >
+                {tag}
+              </span>
+            ))}
+            {mentor.expertise.length > 2 && (
+              <span className="inline-flex items-center rounded-full bg-gray-100 dark:bg-gray-700 px-2.5 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400">
+                +{mentor.expertise.length - 2} more
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Skills */}
+        {mentor.skills.length > 0 && (
+          <div className="flex flex-wrap gap-1.5" aria-label="Skills">
+            {mentor.skills.map((skill) => (
+              <span
+                key={skill}
+                className="inline-flex items-center rounded-full bg-gray-100 dark:bg-gray-700/60 px-2.5 py-0.5 text-xs font-medium text-gray-700 dark:text-gray-300"
+              >
+                {skill}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Footer: price + CTA */}
+      <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 dark:bg-gray-800/50 dark:border-gray-700/60 flex items-center justify-between gap-3">
+        <div className="flex flex-col leading-tight">
+          <span className="text-[11px] uppercase tracking-wider text-gray-500 dark:text-gray-400 font-semibold">
+            per session
+          </span>
+          <span className="text-lg font-bold text-gray-900 dark:text-white">
+            ${mentor.pricePerSession}
+          </span>
+        </div>
+
+        <Link
+          href={profileHref}
+          aria-disabled={isFullyBooked}
+          tabIndex={isFullyBooked ? -1 : undefined}
+          className={`inline-flex items-center gap-1 text-sm font-semibold rounded-lg px-3.5 py-2 transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 ${
+            isFullyBooked
+              ? 'bg-gray-200 text-gray-400 cursor-not-allowed pointer-events-none dark:bg-gray-700 dark:text-gray-500'
+              : 'bg-cyan-600 text-white hover:bg-cyan-700'
+          }`}
+          aria-label={
+            isFullyBooked
+              ? `${mentor.name} is fully booked — view profile for waitlist`
+              : `View profile and book a session with ${mentor.name}`
+          }
+        >
+          View Profile
+          {!isFullyBooked && (
+            <svg
+              className="w-4 h-4 transform group-hover:translate-x-0.5 transition-transform"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+          )}
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/components/mentors/ExpertiseFilter.tsx
+++ b/components/mentors/ExpertiseFilter.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { EXPERTISE_OPTIONS, type Expertise } from './data';
+
+interface ExpertiseFilterProps {
+  /** Currently selected expertise tags (rendered as checked). */
+  selected: readonly Expertise[];
+  /** Number of mentors per expertise — used to display counts next to labels. */
+  counts: Record<Expertise, number>;
+  /** Toggle a single expertise tag on/off. */
+  onToggle: (expertise: Expertise) => void;
+  /** Reset all expertise tags in this section. */
+  onClear: () => void;
+}
+
+/**
+ * Build a stable, deterministic, DOM-safe id for a checkbox input.
+ * Lower-cased + hyphenated so it survives in any HTML environment.
+ */
+function checkboxId(expertise: Expertise): string {
+  return `expertise-${expertise.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
+}
+
+export default function ExpertiseFilter({
+  selected,
+  counts,
+  onToggle,
+  onClear,
+}: ExpertiseFilterProps) {
+  const hasSelection = selected.length > 0;
+
+  return (
+    <fieldset className="border-0 p-0 m-0">
+      <div className="flex items-center justify-between mb-3">
+        <legend className="text-sm font-semibold text-gray-900 dark:text-white tracking-tight">
+          Expertise
+        </legend>
+        {hasSelection && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-xs font-semibold text-cyan-600 hover:text-cyan-700 dark:text-cyan-400 dark:hover:text-cyan-300 focus:outline-none focus:underline"
+            aria-label="Clear expertise filters"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      <ul role="list" className="flex flex-col gap-2.5">
+        {EXPERTISE_OPTIONS.map((expertise) => {
+          const id = checkboxId(expertise);
+          const checked = selected.includes(expertise);
+          const count = counts[expertise] ?? 0;
+          return (
+            <li key={expertise}>
+              <label
+                htmlFor={id}
+                className={`group flex items-center justify-between gap-3 cursor-pointer rounded-lg px-2 py-1.5 transition-colors ${
+                  checked
+                    ? 'bg-cyan-50 dark:bg-cyan-900/25'
+                    : 'hover:bg-gray-50 dark:hover:bg-gray-800/60'
+                }`}
+              >
+                <span className="flex items-center gap-2.5 min-w-0">
+                  <input
+                    id={id}
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => onToggle(expertise)}
+                    className="h-4 w-4 shrink-0 rounded border-gray-300 text-cyan-600 focus:ring-cyan-500 focus:ring-2 dark:border-gray-600 dark:bg-gray-800 dark:focus:ring-offset-gray-900"
+                  />
+                  <span
+                    className={`text-sm truncate ${
+                      checked
+                        ? 'font-semibold text-cyan-700 dark:text-cyan-300'
+                        : 'text-gray-700 dark:text-gray-300 group-hover:text-gray-900 dark:group-hover:text-white'
+                    }`}
+                  >
+                    {expertise}
+                  </span>
+                </span>
+                <span
+                  className={`shrink-0 text-xs font-medium tabular-nums rounded-full px-2 py-0.5 ${
+                    checked
+                      ? 'bg-cyan-100 text-cyan-800 dark:bg-cyan-800/60 dark:text-cyan-200'
+                      : 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400'
+                  }`}
+                  aria-hidden="true"
+                >
+                  {count}
+                </span>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+    </fieldset>
+  );
+}

--- a/components/mentors/data.ts
+++ b/components/mentors/data.ts
@@ -1,0 +1,223 @@
+import type { AvailabilityStatus } from '@/components/MentorAvailabilityBadge';
+
+/**
+ * High-level expertise areas used to group mentors on the discovery page.
+ * Exported as a string-literal union so the type checker can validate
+ * lookup tables (filter counts, mock data, etc.).
+ */
+export type Expertise =
+  | 'Frontend Development'
+  | 'Backend Engineering'
+  | 'Full-Stack Engineering'
+  | 'Mobile Development'
+  | 'DevOps & Cloud'
+  | 'Data Science & ML'
+  | 'UI/UX Design'
+  | 'Product Management'
+  | 'System Architecture'
+  | 'Engineering Leadership';
+
+/**
+ * Stable order in which filters are rendered.
+ * Using `as const` keeps literal types so the `Expertise` union is preserved.
+ */
+export const EXPERTISE_OPTIONS = [
+  'Frontend Development',
+  'Backend Engineering',
+  'Full-Stack Engineering',
+  'Mobile Development',
+  'DevOps & Cloud',
+  'Data Science & ML',
+  'UI/UX Design',
+  'Product Management',
+  'System Architecture',
+  'Engineering Leadership',
+] as const satisfies readonly Expertise[];
+
+export interface Mentor {
+  id: string;
+  name: string;
+  title: string;
+  company: string;
+  bio: string;
+  avatarUrl?: string;
+  rating: number;
+  reviewCount: number;
+  /** Price in USD per one mentoring session. */
+  pricePerSession: number;
+  skills: string[];
+  expertise: Expertise[];
+  experienceYears: number;
+  availability: AvailabilityStatus;
+}
+
+export const MOCK_MENTORS: Mentor[] = [
+  {
+    id: 'sarah-doe',
+    name: 'Sarah Doe',
+    title: 'Staff Frontend Engineer',
+    company: 'Google',
+    bio: 'Helps engineers level up on React, TypeScript, and Next.js with practical code review and architecture guidance.',
+    rating: 4.9,
+    reviewCount: 238,
+    pricePerSession: 120,
+    skills: ['React', 'TypeScript', 'Next.js'],
+    expertise: ['Frontend Development', 'Full-Stack Engineering'],
+    experienceYears: 6,
+    availability: 'available',
+  },
+  {
+    id: 'john-smith',
+    name: 'John Smith',
+    title: 'Senior Product Manager',
+    company: 'Microsoft',
+    bio: 'Specializes in product strategy, roadmap planning, and aligning cross-functional teams around measurable customer outcomes.',
+    rating: 4.7,
+    reviewCount: 152,
+    pricePerSession: 95,
+    skills: ['Strategy', 'Roadmapping', 'OKRs'],
+    expertise: ['Product Management', 'Engineering Leadership'],
+    experienceYears: 8,
+    availability: 'available',
+  },
+  {
+    id: 'jane-roe',
+    name: 'Jane Roe',
+    title: 'Lead UX Designer',
+    company: 'Apple',
+    bio: 'Passionate about design systems, prototyping, and shipping accessible, intuitive interfaces at scale.',
+    rating: 4.8,
+    reviewCount: 89,
+    pricePerSession: 110,
+    skills: ['Figma', 'Design Systems', 'Prototyping'],
+    expertise: ['UI/UX Design', 'Frontend Development'],
+    experienceYears: 7,
+    availability: 'busy',
+  },
+  {
+    id: 'michael-chen',
+    name: 'Michael Chen',
+    title: 'Principal Engineer',
+    company: 'Meta',
+    bio: 'Designs distributed systems and mentors engineers on backend architecture, database modeling, and reliability.',
+    rating: 4.9,
+    reviewCount: 312,
+    pricePerSession: 150,
+    skills: ['Distributed Systems', 'PostgreSQL', 'Go'],
+    expertise: ['Backend Engineering', 'System Architecture'],
+    experienceYears: 12,
+    availability: 'available',
+  },
+  {
+    id: 'emily-davis',
+    name: 'Emily Davis',
+    title: 'Senior Data Scientist',
+    company: 'Netflix',
+    bio: 'Guides mentees through statistical modeling, experimentation, and production machine learning workflows.',
+    rating: 4.6,
+    reviewCount: 76,
+    pricePerSession: 115,
+    skills: ['Python', 'TensorFlow', 'Statistics'],
+    expertise: ['Data Science & ML'],
+    experienceYears: 5,
+    availability: 'available',
+  },
+  {
+    id: 'alex-kumar',
+    name: 'Alex Kumar',
+    title: 'Engineering Manager',
+    company: 'Stripe',
+    bio: 'Coaches engineers transitioning into leadership roles, with hands-on system design and career strategy support.',
+    rating: 4.9,
+    reviewCount: 201,
+    pricePerSession: 140,
+    skills: ['Leadership', 'System Design', 'Career Coaching'],
+    expertise: ['Engineering Leadership', 'Backend Engineering'],
+    experienceYears: 11,
+    availability: 'available',
+  },
+  {
+    id: 'priya-sharma',
+    name: 'Priya Sharma',
+    title: 'Mobile Lead',
+    company: 'Uber',
+    bio: 'Builds and scales cross-platform mobile apps. Mentors on native iOS/Android and React Native architecture.',
+    rating: 4.7,
+    reviewCount: 124,
+    pricePerSession: 125,
+    skills: ['React Native', 'Swift', 'Kotlin'],
+    expertise: ['Mobile Development', 'Engineering Leadership'],
+    experienceYears: 9,
+    availability: 'busy',
+  },
+  {
+    id: 'david-park',
+    name: 'David Park',
+    title: 'Senior DevOps Engineer',
+    company: 'AWS',
+    bio: 'Helps teams adopt infrastructure-as-code, observability, and reliable deployment practices on AWS.',
+    rating: 4.8,
+    reviewCount: 167,
+    pricePerSession: 130,
+    skills: ['Kubernetes', 'Terraform', 'AWS'],
+    expertise: ['DevOps & Cloud', 'Backend Engineering'],
+    experienceYears: 8,
+    availability: 'available',
+  },
+  {
+    id: 'maria-garcia',
+    name: 'Maria Garcia',
+    title: 'Senior Product Designer',
+    company: 'Figma',
+    bio: 'Designs end-to-end product experiences and mentors designers on interaction craft, accessibility, and storytelling.',
+    rating: 4.8,
+    reviewCount: 143,
+    pricePerSession: 105,
+    skills: ['Figma', 'Interaction Design', 'Accessibility'],
+    expertise: ['UI/UX Design', 'Frontend Development'],
+    experienceYears: 6,
+    availability: 'available',
+  },
+  {
+    id: 'tom-wilson',
+    name: 'Tom Wilson',
+    title: 'Staff Engineer',
+    company: 'Twitter',
+    bio: 'Specialist in large-scale event-driven systems. Helps engineers reason about consistency, throughput, and cost.',
+    rating: 5.0,
+    reviewCount: 421,
+    pricePerSession: 175,
+    skills: ['Kafka', 'Scala', 'Distributed Systems'],
+    expertise: ['System Architecture', 'Backend Engineering', 'Full-Stack Engineering'],
+    experienceYears: 14,
+    availability: 'fully-booked',
+  },
+  {
+    id: 'lisa-brown',
+    name: 'Lisa Brown',
+    title: 'Machine Learning Engineer',
+    company: 'OpenAI',
+    bio: 'Works on production LLM systems. Mentors on evaluation, fine-tuning, and shipping ML features responsibly.',
+    rating: 4.9,
+    reviewCount: 198,
+    pricePerSession: 160,
+    skills: ['PyTorch', 'LLMs', 'Python'],
+    expertise: ['Data Science & ML', 'Backend Engineering'],
+    experienceYears: 7,
+    availability: 'available',
+  },
+  {
+    id: 'carlos-mendez',
+    name: 'Carlos Mendez',
+    title: 'CTO & Co-founder',
+    company: 'Helio Labs',
+    bio: 'Advises early-stage technical leaders on hiring, architecture decisions, and aligning engineering with the business.',
+    rating: 4.7,
+    reviewCount: 82,
+    pricePerSession: 135,
+    skills: ['Leadership', 'Hiring', 'Architecture'],
+    expertise: ['Engineering Leadership', 'Product Management'],
+    experienceYears: 13,
+    availability: 'available',
+  },
+];


### PR DESCRIPTION
## Summary

Resolves both issues assigned to @JudeDaniel6 under the Stellar Wave 6th wave.

- Closes #455 — Create Mentor Discovery Page Layout
- Closes #459 — Add Expertise Filter Section

A new `/discover-mentors` route (already linked from the public `Navbar`) that implements the two-column discovery layout from #455 and fills the sidebar with the expertise filter from #459. **No pre-existing files touched** — the implementation is fully self-contained so it does not depend on the currently broken `components/MentorCard.tsx`.

### New files

| File | Kind | Purpose |
| --- | --- | --- |
| `app/(public)/discover-mentors/page.tsx` | RSC | Page entry. Hero strip + two-column layout shell, exports `metadata` for Next.js 16. |
| `app/(public)/discover-mentors/MentorDiscoveryView.tsx` | `'use client'` | Interactive view that owns filter + sort state, derives `filteredMentors` via `useMemo`, shows the live result count, sort dropdown, and empty state. |
| `components/mentors/ExpertiseFilter.tsx` | `'use client'` | The expertise filter section requested in #459 — accessible `fieldset`/`legend` of checkboxes with per-tag mentor counts and a Clear action. |
| `components/mentors/DiscoveryMentorCard.tsx` | RSC-friendly | Self-contained mentor card that reuses the existing `StarRating` and `MentorAvailabilityBadge` working components. |
| `components/mentors/data.ts` | Data | Typed mock mentor list (`Mentor` interface + `Expertise` literal union + `EXPERTISE_OPTIONS` guarded with `as const satisfies …`). |

## Acceptance criteria

### #455 — Mentor Discovery Page Layout
- Two-column layout: filters sidebar (left, sticky on `md+`) + mentor listing area (right).
- Responsive: collapses to a single column on `<md` screens via `flex-col md:flex-row`.
- Proper spacing and alignment: page uses `max-w-screen-xl mx-auto px-4` consistent with the existing `(public)` layouts; sidebar width `w-full md:w-64 lg:w-72`; grid gap-6; align-items consistent.

### #459 — Expertise Filter Section
- Implemented as a real, interactive section in the sidebar (`fieldset` + `legend` "Expertise").
- 10 selectable expertise tags (Frontend, Backend, Full-Stack, Mobile, DevOps & Cloud, Data Science & ML, UI/UX Design, Product Management, System Architecture, Engineering Leadership).
- Each option displays a count of mentors who offer it.
- Selecting tags narrows the visible mentor grid live; toggling off restores visibility. OR-semantics within the section (matches any selected tag).
- Clear affordance present in two places: the section header and the empty-state CTA.

## Accessibility

- `aria-live="polite"` on the result count.
- `fieldset`/`legend` around expertise checkboxes; each `<label htmlFor>` properly linked to its `<input id>`.
- `aria-label`s on every icon-only CTA and `<aside aria-label="Mentor filters">`, `<section aria-label="Mentor results">`.
- `role="list"` on both grids; keyboard-focusable `Clear all`, focus rings on select + buttons.
- Dark-mode classes mirror the existing convention (`dark:bg-gray-900`, `dark:border-gray-700/80`, …).

## Type-safety / hygiene

- `Expertise` is a literal string union; `EXPERTISE_OPTIONS` is guarded with `as const satisfies readonly Expertise[]` so a typo in either the union or the runtime list is a compile error.
- `Record<Expertise, number>` enforces exhaustive counts.
- No `any` usage in the new code.
- `npx tsc --noEmit` reports **no errors** for the new files.
- `npx eslint` reports **no warnings/errors** for the new files.

## Out of scope / intentionally left alone

These pre-existing files have in-progress edits unrelated to my assigned issues; they were deliberately left untouched, as fixing them was not assigned to me and is out of scope for this PR:

- `components/MentorCard.tsx` (3 duplicate `export default function MentorCard` — separate issue).
- `app/(public)/page.tsx` and `app/(public)/resources/page.tsx` (in-progress merges with unclosed JSX — separate issues).

---

Generated as part of the Stellar Wave 6th wave for @JudeDaniel6.