### PR TITLE
feat: community loading skeletons, empty/error states, responsive sidebar

### DIFF
--- a/components/community/CommunityEmptyState.tsx
+++ b/components/community/CommunityEmptyState.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+interface CommunityEmptyStateProps {
+  type?: 'discussions' | 'search' | 'category';
+  onAction?: () => void;
+}
+
+const configs = {
+  discussions: {
+    heading: 'No discussions yet',
+    text: 'Be the first to start a conversation in this community.',
+    cta: 'Start Discussion',
+  },
+  search: {
+    heading: 'No results found',
+    text: 'Try adjusting your search or filters to find what you\'re looking for.',
+    cta: undefined,
+  },
+  category: {
+    heading: 'No discussions in this category',
+    text: 'Check back later or explore other categories.',
+    cta: 'View All Discussions',
+  },
+};
+
+export default function CommunityEmptyState({ type = 'discussions', onAction }: CommunityEmptyStateProps) {
+  const config = configs[type];
+  return (
+    <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
+      <svg className="w-16 h-16 text-gray-300 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+      </svg>
+      <h3 className="text-lg font-semibold text-gray-900 mb-1">{config.heading}</h3>
+      <p className="text-sm text-gray-500 max-w-sm mb-6">{config.text}</p>
+      {config.cta && onAction && (
+        <button onClick={onAction} className="px-5 py-2.5 rounded-lg bg-cyan-600 text-white text-sm font-medium hover:bg-cyan-700 transition-colors">
+          {config.cta}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/community/CommunityErrorState.tsx
+++ b/components/community/CommunityErrorState.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+interface CommunityErrorStateProps {
+  message?: string;
+  onRetry?: () => void;
+}
+
+export default function CommunityErrorState({ message = 'Something went wrong loading discussions.', onRetry }: CommunityErrorStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
+      <div className="mb-4 rounded-full bg-red-100 p-3">
+        <svg className="h-6 w-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+      </div>
+      <p className="text-sm text-gray-700 mb-4 max-w-sm">{message}</p>
+      {onRetry && (
+        <button onClick={onRetry} className="px-5 py-2.5 rounded-lg bg-cyan-600 text-white text-sm font-medium hover:bg-cyan-700 transition-colors">
+          Try Again
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/community/CommunitySidebar.tsx
+++ b/components/community/CommunitySidebar.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState } from 'react';
+
+interface CommunitySidebarProps {
+  children: React.ReactNode;
+}
+
+export default function CommunitySidebar({ children }: CommunitySidebarProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="lg:hidden fixed bottom-4 right-4 z-50 p-3 rounded-full bg-cyan-600 text-white shadow-lg hover:bg-cyan-700 transition-colors"
+        aria-label="Toggle sidebar"
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div
+          className="lg:hidden fixed inset-0 bg-black/30 z-40"
+          onClick={() => setIsOpen(false)}
+        />
+      )}
+
+      <aside
+        className={`
+          fixed top-0 right-0 z-40 h-full w-80 bg-white shadow-lg transform transition-transform duration-200
+          lg:static lg:z-auto lg:translate-x-0 lg:w-full lg:h-auto lg:shadow-none lg:rounded-lg
+          ${isOpen ? 'translate-x-0' : 'translate-x-full'}
+        `}
+      >
+        <div className="p-4 lg:p-0">
+          <button
+            onClick={() => setIsOpen(false)}
+            className="lg:hidden absolute top-3 right-3 p-1 text-gray-400 hover:text-gray-600"
+            aria-label="Close sidebar"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+          {children}
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/components/community/DiscussionCard.tsx
+++ b/components/community/DiscussionCard.tsx
@@ -10,119 +10,52 @@ import type { DiscussionCardProps } from '@/lib/community-types';
 export default function DiscussionCard({ discussion, onLike, onBookmark, onClick, onDelete, currentUserId }: DiscussionCardProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const isAuthor = currentUserId === discussion.author.id;
-
-  const handleDelete = () => {
-    setShowDeleteDialog(true);
-  };
-
-  const handleConfirmDelete = () => {
-    onDelete?.(discussion.id);
-    setShowDeleteDialog(false);
-  };
-
-  const handleCancelDelete = () => {
-    setShowDeleteDialog(false);
-  };
-
-  return (
-    <>
-      <article
-        className="bg-white rounded-lg shadow p-5 hover:shadow-md transition-shadow cursor-pointer"
-        onClick={() => onClick?.(discussion.id)}
-        role="button"
-        tabIndex={0}
-        onKeyDown={(e) => { if (e.key === 'Enter') onClick?.(discussion.id); }}
-      >
-        <div className="flex items-start gap-3 mb-3">
-          <Avatar
-            src={discussion.author.avatarUrl}
-            alt={discussion.author.name}
-            name={discussion.author.name}
-            size="sm"
-          />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <span className="text-sm font-medium text-gray-900 truncate">
-                {discussion.author.name}
-              </span>
-              {discussion.author.role && (
-                <span className="text-xs text-gray-500">{discussion.author.role}</span>
-              )}
-              <CategoryBadge category={discussion.category} />
-            </div>
-            <h3 className="text-base font-semibold text-gray-900 leading-snug">
-              {discussion.title}
-            </h3>
-export default function DiscussionCard({ discussion, onLike, onBookmark, onClick }: DiscussionCardProps) {
   const isPinned = discussion.isPinned ?? false;
   const isLocked = discussion.isLocked ?? false;
 
   return (
-    <article
-      className={`bg-white rounded-lg shadow p-5 hover:shadow-md transition-shadow cursor-pointer relative ${
-        isPinned ? 'border-l-4 border-cyan-500 bg-cyan-50/30' : ''
-      } ${isLocked ? 'opacity-90' : ''}`}
-      onClick={() => onClick?.(discussion.id)}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => { if (e.key === 'Enter') onClick?.(discussion.id); }}
-      aria-label={`Discussion: ${discussion.title}${isPinned ? ', pinned' : ''}${isLocked ? ', locked' : ''}`}
-    >
-      {/* Pin and Lock status badges */}
-      {(isPinned || isLocked) && (
-        <div className="flex items-center gap-2 mb-3">
-          {isPinned && (
-            <span
-              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-cyan-100 text-cyan-700 text-xs font-medium"
-              aria-label="Pinned discussion"
-              data-testid="pin-badge"
-            >
-              {/* Pin icon */}
-              <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2z" />
-              </svg>
-              Pinned
-            </span>
-          )}
-          {isLocked && (
-            <span
-              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 text-xs font-medium"
-              aria-label="Locked discussion"
-              data-testid="lock-badge"
-            >
-              {/* Lock icon */}
-              <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z" />
-              </svg>
-              Locked
-            </span>
-          )}
-        </div>
-      )}
-
-      <div className="flex items-start gap-3 mb-3">
-        <Avatar
-          src={discussion.author.avatarUrl}
-          alt={discussion.author.name}
-          name={discussion.author.name}
-          size="sm"
-        />
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-1">
-            <span className="text-sm font-medium text-gray-900 truncate">
-              {discussion.author.name}
-            </span>
-            {discussion.author.role && (
-              <span className="text-xs text-gray-500">{discussion.author.role}</span>
+    <>
+      <article
+        className={`bg-white rounded-lg shadow p-5 hover:shadow-md transition-shadow cursor-pointer relative ${
+          isPinned ? 'border-l-4 border-cyan-500 bg-cyan-50/30' : ''
+        } ${isLocked ? 'opacity-90' : ''}`}
+        onClick={() => onClick?.(discussion.id)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => { if (e.key === 'Enter') onClick?.(discussion.id); }}
+        aria-label={`Discussion: ${discussion.title}${isPinned ? ', pinned' : ''}${isLocked ? ', locked' : ''}`}
+      >
+        {(isPinned || isLocked) && (
+          <div className="flex items-center gap-2 mb-3">
+            {isPinned && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-cyan-100 text-cyan-700 text-xs font-medium" data-testid="pin-badge">
+                <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor"><path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2z" /></svg>
+                Pinned
+              </span>
             )}
-            <CategoryBadge category={discussion.category} />
+            {isLocked && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 text-xs font-medium" data-testid="lock-badge">
+                <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor"><path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1v2z" /></svg>
+                Locked
+              </span>
+            )}
           </div>
-          {isAuthor && (
+        )}
+
+        <div className="flex items-start gap-3 mb-3">
+          <Avatar src={discussion.author.avatarUrl} alt={discussion.author.name} name={discussion.author.name} size="sm" />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <span className="text-sm font-medium text-gray-900 truncate">{discussion.author.name}</span>
+              {discussion.author.role && <span className="text-xs text-gray-500">{discussion.author.role}</span>}
+              <CategoryBadge category={discussion.category} />
+            </div>
+            <h3 className="text-base font-semibold text-gray-900 leading-snug">{discussion.title}</h3>
+          </div>
+
+          {isAuthor && onDelete && (
             <button
-              onClick={(e) => {
-                e.stopPropagation();
-                handleDelete();
-              }}
+              onClick={(e) => { e.stopPropagation(); setShowDeleteDialog(true); }}
               className="text-gray-400 hover:text-red-600 transition-colors p-1"
               aria-label="Delete discussion"
             >
@@ -136,17 +69,26 @@ export default function DiscussionCard({ discussion, onLike, onBookmark, onClick
         {discussion.tags && discussion.tags.length > 0 && (
           <div className="flex flex-wrap gap-1.5 mb-3">
             {discussion.tags.map((tag) => (
-              <span
-                key={tag}
-                className="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600"
-              >
+              <span key={tag} className="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
                 #{tag}
               </span>
             ))}
           </div>
         )}
 
-        <DiscussionMetadata metadata={discussion} onLike={onLike} onBookmark={onBookmark} />
+        {isLocked && (
+          <p className="text-xs text-amber-600 mb-3 flex items-center gap-1" data-testid="locked-notice">
+            <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1v2z" /></svg>
+            This discussion is locked — no new replies.
+          </p>
+        )}
+
+        <DiscussionMetadata
+          metadata={discussion}
+          onLike={onLike}
+          onBookmark={onBookmark}
+          disableInteractions={isLocked}
+        />
       </article>
 
       <ConfirmDialog
@@ -155,25 +97,9 @@ export default function DiscussionCard({ discussion, onLike, onBookmark, onClick
         message="Are you sure you want to delete this discussion? This action cannot be undone."
         confirmText="Delete"
         cancelText="Cancel"
-        onConfirm={handleConfirmDelete}
-        onCancel={handleCancelDelete}
+        onConfirm={() => { onDelete?.(discussion.id); setShowDeleteDialog(false); }}
+        onCancel={() => setShowDeleteDialog(false)}
       />
     </>
-      {isLocked && (
-        <p className="text-xs text-amber-600 mb-3 flex items-center gap-1" data-testid="locked-notice">
-          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z" />
-          </svg>
-          This discussion is locked — no new replies.
-        </p>
-      )}
-
-      <DiscussionMetadata
-        metadata={discussion}
-        onLike={onLike}
-        onBookmark={onBookmark}
-        disableInteractions={isLocked}
-      />
-    </article>
   );
 }

--- a/components/community/DiscussionMetadata.tsx
+++ b/components/community/DiscussionMetadata.tsx
@@ -7,17 +7,12 @@ interface Props {
   onFollow?: (userId: string) => void;
   onShare?: (id: string) => void;
   onReport?: (id: string) => void;
-}
-
-export default function DiscussionMetadata({ metadata, onLike, onBookmark, onFollow, onShare, onReport }: Props) {
   disableInteractions?: boolean;
 }
 
-export default function DiscussionMetadata({ metadata, onLike, onBookmark, disableInteractions = false }: Props) {
+export default function DiscussionMetadata({ metadata, onLike, onBookmark, onFollow, onShare, onReport, disableInteractions = false }: Props) {
   const timeAgo = (date: string) => {
-    const now = Date.now();
-    const then = new Date(date).getTime();
-    const diffMs = now - then;
+    const diffMs = Date.now() - new Date(date).getTime();
     const minutes = Math.floor(diffMs / 60000);
     if (minutes < 1) return 'just now';
     if (minutes < 60) return `${minutes}m ago`;
@@ -34,9 +29,7 @@ export default function DiscussionMetadata({ metadata, onLike, onBookmark, disab
         <button
           onClick={() => !disableInteractions && onLike?.(metadata.id)}
           className={`flex items-center gap-1 transition-colors ${
-            disableInteractions
-              ? 'text-gray-400 cursor-not-allowed'
-              : `hover:text-cyan-600 ${metadata.isLiked ? 'text-cyan-600' : ''}`
+            disableInteractions ? 'text-gray-400 cursor-not-allowed' : `hover:text-cyan-600 ${metadata.isLiked ? 'text-cyan-600' : ''}`
           }`}
           aria-label={metadata.isLiked ? 'Unlike' : 'Like'}
           disabled={disableInteractions}
@@ -94,29 +87,16 @@ export default function DiscussionMetadata({ metadata, onLike, onBookmark, disab
         )}
 
         <button
-          onClick={() => onBookmark?.(metadata.id)}
-          className={`hover:text-cyan-600 transition-colors ${metadata.isBookmarked ? 'text-cyan-600' : ''}`}
+          onClick={() => !disableInteractions && onBookmark?.(metadata.id)}
+          className={`transition-colors ${disableInteractions ? 'text-gray-300 cursor-not-allowed' : `hover:text-cyan-600 ${metadata.isBookmarked ? 'text-cyan-600' : ''}`}`}
           aria-label={metadata.isBookmarked ? 'Remove bookmark' : 'Bookmark'}
+          disabled={disableInteractions}
         >
           <svg className="w-4 h-4" fill={metadata.isBookmarked ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
           </svg>
         </button>
       </div>
-      <button
-        onClick={() => !disableInteractions && onBookmark?.(metadata.id)}
-        className={`ml-auto transition-colors ${
-          disableInteractions
-            ? 'text-gray-300 cursor-not-allowed'
-            : `hover:text-cyan-600 ${metadata.isBookmarked ? 'text-cyan-600' : ''}`
-        }`}
-        aria-label={metadata.isBookmarked ? 'Remove bookmark' : 'Bookmark'}
-        disabled={disableInteractions}
-      >
-        <svg className="w-4 h-4" fill={metadata.isBookmarked ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-        </svg>
-      </button>
     </div>
   );
 }

--- a/components/skeletons/DiscussionCardSkeleton.tsx
+++ b/components/skeletons/DiscussionCardSkeleton.tsx
@@ -1,0 +1,22 @@
+export default function DiscussionCardSkeleton() {
+  return (
+    <div className="bg-white rounded-lg shadow p-5 animate-pulse">
+      <div className="flex items-start gap-3 mb-3">
+        <div className="w-10 h-10 rounded-full bg-gray-200" />
+        <div className="flex-1 space-y-2">
+          <div className="h-3 w-24 rounded bg-gray-200" />
+          <div className="h-4 w-3/4 rounded bg-gray-200" />
+        </div>
+      </div>
+      <div className="space-y-2 mb-3">
+        <div className="h-3 w-full rounded bg-gray-200" />
+        <div className="h-3 w-5/6 rounded bg-gray-200" />
+      </div>
+      <div className="flex gap-4">
+        <div className="h-3 w-12 rounded bg-gray-200" />
+        <div className="h-3 w-12 rounded bg-gray-200" />
+        <div className="h-3 w-12 rounded bg-gray-200" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Changes
- **#693**: Created `DiscussionCardSkeleton` loading skeleton for discussion cards
- **#694**: Created `CommunityEmptyState` component for empty discussion states
- **#695**: Created `CommunityErrorState` component for error states
- **#696**: Created `CommunitySidebar` with responsive mobile/desktop behavior
- Fixed broken `DiscussionCard` and `DiscussionMetadata` components (duplicate code from merge conflicts)

## Closes
Closes #693
Closes #694
Closes #695
Closes #696