### PR TITLE
feat: community event card, stats widget, stat card, discussion search

### DIFF
--- a/components/community/CommunityEventCard.tsx
+++ b/components/community/CommunityEventCard.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+interface CommunityEventCardProps {
+  title: string;
+  host: string;
+  date: string;
+  time: string;
+  attendeeCount: number;
+  onRegister?: () => void;
+}
+
+export default function CommunityEventCard({ title, host, date, time, attendeeCount, onRegister }: CommunityEventCardProps) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4 hover:shadow-md transition-shadow">
+      <h4 className="font-semibold text-gray-900 mb-1">{title}</h4>
+      <p className="text-sm text-gray-500 mb-2">Hosted by {host}</p>
+      <div className="flex gap-3 text-xs text-gray-500 mb-3">
+        <span className="flex items-center gap-1">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          {date}
+        </span>
+        <span className="flex items-center gap-1">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          {time}
+        </span>
+      </div>
+      <p className="text-xs text-gray-400 mb-3">{attendeeCount} attending</p>
+      {onRegister && (
+        <button onClick={onRegister} className="w-full px-3 py-1.5 rounded-lg bg-cyan-600 text-white text-sm font-medium hover:bg-cyan-700 transition-colors">
+          Register
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/community/CommunityStatCard.tsx
+++ b/components/community/CommunityStatCard.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+interface CommunityStatCardProps {
+  label: string;
+  value: number | string;
+  trend?: { value: number; isPositive: boolean };
+  icon?: React.ReactNode;
+}
+
+export default function CommunityStatCard({ label, value, trend, icon }: CommunityStatCardProps) {
+  return (
+    <div className="bg-white rounded-lg shadow p-4 flex items-center gap-3 hover:shadow-md transition-shadow">
+      {icon && (
+        <div className="w-10 h-10 bg-cyan-100 rounded-full flex items-center justify-center flex-shrink-0 text-cyan-600">
+          {icon}
+        </div>
+      )}
+      <div className="flex-1 min-w-0">
+        <p className="text-xl font-bold text-gray-900">{value}</p>
+        <p className="text-xs text-gray-500 truncate">{label}</p>
+      </div>
+      {trend && (
+        <span className={`text-xs font-medium ${trend.isPositive ? 'text-green-600' : 'text-red-600'}`}>
+          {trend.isPositive ? '+' : ''}{trend.value}%
+        </span>
+      )}
+    </div>
+  );
+}

--- a/components/community/CommunityStatsWidget.tsx
+++ b/components/community/CommunityStatsWidget.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+interface CommunityStatsWidgetProps {
+  totalDiscussions: number;
+  totalMembers: number;
+  activeNow: number;
+  totalEvents: number;
+}
+
+export default function CommunityStatsWidget({ totalDiscussions, totalMembers, activeNow, totalEvents }: CommunityStatsWidgetProps) {
+  const stats = [
+    { label: 'Discussions', value: totalDiscussions, icon: 'M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z' },
+    { label: 'Members', value: totalMembers, icon: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z' },
+    { label: 'Active Now', value: activeNow, icon: 'M13 10V3L4 14h7v7l9-11h-7z' },
+    { label: 'Events', value: totalEvents, icon: 'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z' },
+  ];
+
+  return (
+    <div className="bg-white rounded-lg shadow p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">Community Stats</h2>
+      <div className="grid grid-cols-2 gap-4">
+        {stats.map((stat) => (
+          <div key={stat.label} className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-cyan-100 rounded-full flex items-center justify-center flex-shrink-0">
+              <svg className="w-5 h-5 text-cyan-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={stat.icon} />
+              </svg>
+            </div>
+            <div>
+              <p className="text-lg font-bold text-gray-900">{stat.value}</p>
+              <p className="text-xs text-gray-500">{stat.label}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/community/DiscussionSearch.tsx
+++ b/components/community/DiscussionSearch.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState } from 'react';
+import { useDebounce } from '@/hooks/useDebounce';
+
+interface DiscussionSearchProps {
+  onSearch: (query: string) => void;
+  placeholder?: string;
+}
+
+export default function DiscussionSearch({ onSearch, placeholder = 'Search discussions...' }: DiscussionSearchProps) {
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebounce(query);
+
+  const handleChange = (value: string) => {
+    setQuery(value);
+    onSearch(debouncedQuery);
+  };
+
+  return (
+    <div className="relative">
+      <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+      </svg>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => handleChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
+        aria-label="Search discussions"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Changes
- **#685**: Created `CommunityEventCard` reusable event card with host, date, time, attendee count, and register button
- **#686**: Created `CommunityStatsWidget` displaying discussions, members, active users, and events in a grid
- **#687**: Created `CommunityStatCard` with label, value, trend indicator, and icon support
- **#688**: Created `DiscussionSearch` with debounced input and search icon

## Closes
Closes #685
Closes #686
Closes #687
Closes #688