### PR TITLE
feat(ui): create reusable article list item component

### DIFF
--- a/__tests__/components/ArticleListItem.test.tsx
+++ b/__tests__/components/ArticleListItem.test.tsx
@@ -1,0 +1,59 @@
+import '@testing-library/jest-dom/jest-globals';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ArticleListItem from '@/components/ArticleListItem';
+
+const defaultProps = {
+  category: 'Career',
+  title: 'How to Land Your First Tech Job',
+  author: 'Jane Doe',
+  readTime: '5 min read',
+  href: '/resources/articles/test-article',
+};
+
+describe('ArticleListItem', () => {
+  it('renders category, title, author, and read time', () => {
+    render(<ArticleListItem {...defaultProps} />);
+    expect(screen.getByText('Career')).toBeInTheDocument();
+    expect(screen.getByText('How to Land Your First Tech Job')).toBeInTheDocument();
+    expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();
+    expect(screen.getByText(/5 min read/)).toBeInTheDocument();
+  });
+
+  it('renders a trending arrow icon', () => {
+    const { container } = render(<ArticleListItem {...defaultProps} />);
+    const svgs = container.querySelectorAll('svg');
+    expect(svgs.length).toBe(1);
+  });
+
+  it('renders as a link with the provided href', () => {
+    render(<ArticleListItem {...defaultProps} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/resources/articles/test-article');
+  });
+
+  it('generates a slug from title when href is not provided', () => {
+    const { href, ...rest } = defaultProps;
+    render(<ArticleListItem {...rest} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/resources/articles/how-to-land-your-first-tech-job');
+  });
+
+  it('uses semantic HTML: article and h3 elements', () => {
+    const { container } = render(<ArticleListItem {...defaultProps} />);
+    expect(container.querySelector('article')).toBeInTheDocument();
+    expect(container.querySelector('h3')).toBeInTheDocument();
+  });
+
+  it('applies dark mode classes', () => {
+    const { container } = render(<ArticleListItem {...defaultProps} />);
+    const link = container.querySelector('a');
+    expect(link?.className).toContain('dark:hover:bg-gray-800/60');
+    expect(link?.className).toContain('dark:focus:ring-cyan-500');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<ArticleListItem {...defaultProps} className="custom-class" />);
+    expect(container.querySelector('article')?.className).toContain('custom-class');
+  });
+});

--- a/components/ArticleListItem.tsx
+++ b/components/ArticleListItem.tsx
@@ -1,46 +1,39 @@
 import React from 'react';
 import Link from 'next/link';
+import { TrendingUp } from 'lucide-react';
+import type { Article } from '@/lib/types';
 
-interface ArticleListItemProps {
-  category: string;
-  title: string;
-  author: string;
-  readTime: string;
-  href?: string;
+interface ArticleListItemProps extends Article {
+  className?: string;
 }
 
-export default function ArticleListItem({ category, title, author, readTime, href }: ArticleListItemProps) {
-  const articleSlug = title.toLowerCase().replace(/ /g, '-').replace(/[^a-z0-p\-]/g, '');
+export default function ArticleListItem({ category, title, author, readTime, href, className = '' }: ArticleListItemProps) {
+  const articleSlug = title.toLowerCase().replace(/ /g, '-').replace(/[^a-z0-9-]/g, '');
   const targetHref = href || `/resources/articles/${articleSlug}`;
 
   return (
-    <Link
-      href={targetHref}
-      className="flex items-center justify-between gap-4 py-4 px-2 hover:bg-slate-50 dark:hover:bg-gray-800/60 rounded-xl transition-all group focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2"
-    >
-      <div>
-        <span className="text-xs font-semibold text-cyan-600 dark:text-cyan-400 uppercase tracking-wide">
-          {category}
-        </span>
-        <h3 className="text-base font-bold text-gray-900 dark:text-white mt-1 group-hover:text-cyan-600 dark:group-hover:text-cyan-400 transition-colors">
-          {title}
-        </h3>
-        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-          By {author} &middot; {readTime}
-        </p>
-      </div>
-      <div className="flex-shrink-0 p-2 bg-slate-50 rounded-full group-hover:bg-cyan-50 group-hover:text-cyan-600 dark:bg-gray-800 dark:group-hover:bg-cyan-900/30 dark:group-hover:text-cyan-400 transition-colors">
-        <svg
-          className="w-4 h-4 text-cyan-600 dark:text-cyan-400 transform group-hover:translate-x-0.5 transition-transform"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2.5"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-        </svg>
-      </div>
-    </Link>
+    <article className={className}>
+      <Link
+        href={targetHref}
+        className="flex items-center justify-between gap-4 py-4 px-2 hover:bg-slate-50 dark:hover:bg-gray-800/60 rounded-xl transition-all group focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2"
+      >
+        <div>
+          <header>
+            <span className="text-xs font-semibold text-cyan-600 dark:text-cyan-400 uppercase tracking-wide">
+              {category}
+            </span>
+          </header>
+          <h3 className="text-base font-bold text-gray-900 dark:text-white mt-1 group-hover:text-cyan-600 dark:group-hover:text-cyan-400 transition-colors">
+            {title}
+          </h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            By {author} &middot; {readTime}
+          </p>
+        </div>
+        <div className="flex-shrink-0 p-2 bg-slate-50 rounded-full group-hover:bg-cyan-50 group-hover:text-cyan-600 dark:bg-gray-800 dark:group-hover:bg-cyan-900/30 dark:group-hover:text-cyan-400 transition-colors">
+          <TrendingUp className="w-4 h-4 text-cyan-600 dark:text-cyan-400 transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform" aria-hidden="true" />
+        </div>
+      </Link>
+    </article>
   );
 }

--- a/issue628.md
+++ b/issue628.md
@@ -1,0 +1,16 @@
+Title
+Create Article List Item Component
+
+Description
+Build reusable article list item.
+
+Must Include
+Category label
+Article title
+Author
+Read time
+Small trending arrow icon
+Acceptance Criteria
+Semantic markup
+Clickable item
+

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,6 +6,14 @@ export type SortOption = 'top-rated' | 'price-asc' | 'price-desc' | 'most-review
 
 export type PriceRangeId = 'any' | 'budget' | 'mid' | 'premium';
 
+export interface Article {
+  category: string;
+  title: string;
+  author: string;
+  readTime: string;
+  href?: string;
+}
+
 export interface Mentor {
   mentorId?: string;
   id?: string;


### PR DESCRIPTION
closes #628 
## Create Article List Item Component

### Description
Build a reusable article list item component with semantic HTML, a trending arrow icon, and full test coverage.

### Changes

- **`lib/types.ts`** — Added `Article` interface (`category`, `title`, `author`, `readTime`, `href?`)
- **`components/ArticleListItem.tsx`** — Rewrote with:
  - Semantic markup (`<article>` wrapper, `<header>` for category label, `<h3>` for title)
  - `TrendingUp` icon from `lucide-react` replacing the previous chevron icon
  - `className` prop for consumer composability
  - Extends the shared `Article` type
- **`__tests__/components/ArticleListItem.test.tsx`** — 7 tests covering:
  - All field rendering (category, title, author, read time)
  - Trending arrow icon presence
  - Link href and slug generation
  - Semantic HTML elements
  - Dark mode class application
  - Custom className merging

### Requirements Fulfilled

| Requirement | Status |
|---|---|
| Category label | ✅ |
| Article title | ✅ |
| Author | ✅ |
| Read time | ✅ |
| Small trending arrow icon | ✅ (`TrendingUp` from `lucide-react`) |
| Semantic markup | ✅ (`<article>`, `<header>`, `<h3>`) |
| Clickable item | ✅ (wrapped in `<Link>`) |
