### PR TITLE
Feat/metadata

### DIFF
--- a/app/CategoryBadge.tsx
+++ b/app/CategoryBadge.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+
+/**
+ * CategoryBadge
+ * A reusable badge component for representing discussion categories,
+ * with colors assigned dynamically based on the category name.
+ *
+ * Usage:
+ *   <CategoryBadge category="Career Growth" />
+ *   <CategoryBadge category="Leadership" />
+ *
+ * If you want to force a specific color instead of the auto-generated one,
+ * pass a `color` prop matching one of the keys in COLOR_MAP (e.g. "teal").
+ */
+
+// Curated set of accessible color combinations (bg + text).
+// Add more entries here if you need a larger palette.
+const COLOR_MAP = {
+  purple: { bg: "#EEEDFE", text: "#3C3489", border: "#AFA9EC" },
+  teal: { bg: "#E1F5EE", text: "#085041", border: "#5DCAA5" },
+  coral: { bg: "#FAECE7", text: "#712B13", border: "#F0997B" },
+  pink: { bg: "#FBEAF0", text: "#72243E", border: "#ED93B1" },
+  blue: { bg: "#E6F1FB", text: "#0C447C", border: "#85B7EB" },
+  green: { bg: "#EAF3DE", text: "#27500A", border: "#97C459" },
+  amber: { bg: "#FAEEDA", text: "#633806", border: "#EF9F27" },
+  gray: { bg: "#F1EFE8", text: "#444441", border: "#B4B2A9" },
+};
+
+const COLOR_KEYS = Object.keys(COLOR_MAP);
+
+// Deterministically map a string to one of the palette colors,
+// so the same category name always gets the same color.
+function hashStringToColorKey(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+    hash |= 0; // convert to 32-bit int
+  }
+  const index = Math.abs(hash) % COLOR_KEYS.length;
+  return COLOR_KEYS[index];
+}
+
+export default function CategoryBadge({ category, color, className = "" }) {
+  const colorKey =
+    color && COLOR_MAP[color] ? color : hashStringToColorKey(category || "");
+  const { bg, text, border } = COLOR_MAP[colorKey];
+
+  return (
+    <span
+      className={className}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        padding: "4px 12px",
+        borderRadius: "999px",
+        fontSize: "13px",
+        fontWeight: 500,
+        backgroundColor: bg,
+        color: text,
+        border: `1px solid ${border}`,
+        whiteSpace: "nowrap",
+        lineHeight: 1.4,
+      }}
+    >
+      {category}
+    </span>
+  );
+}
+
+// --- Demo (remove or replace with your own usage) ---
+export function CategoryBadgeDemo() {
+  const categories = [
+    "Career Growth",
+    "Leadership",
+    "Interview Prep",
+    "Networking",
+  ];
+
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", padding: "16px" }}>
+      {categories.map((cat) => (
+        <CategoryBadge key={cat} category={cat} />
+      ))}
+    </div>
+  );
+}

--- a/components/DiscussionMetadata.tsx
+++ b/components/DiscussionMetadata.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+
+/**
+ * DiscussionMetadata
+ *
+ * Reusable component that displays metadata for a discussion/thread:
+ * posted time, category, like count, and reply count.
+ *
+ * Semantic markup:
+ * - <time dateTime> for the posted timestamp (machine-readable + human-readable)
+ * - <dl>/<dt>/<dd> to represent the label/value metadata pairs
+ * - aria-labels for icon-only or ambiguous numeric content
+ */
+
+function formatRelativeTime(dateInput) {
+  const date = dateInput instanceof Date ? dateInput : new Date(dateInput);
+  const now = new Date();
+  const diffMs = now - date;
+  const diffSec = Math.round(diffMs / 1000);
+  const diffMin = Math.round(diffSec / 60);
+  const diffHour = Math.round(diffMin / 60);
+  const diffDay = Math.round(diffHour / 24);
+
+  if (diffSec < 60) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHour < 24) return `${diffHour}h ago`;
+  if (diffDay < 7) return `${diffDay}d ago`;
+
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatCount(count) {
+  if (count >= 1000) return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  return String(count);
+}
+
+export default function DiscussionMetadata({
+  postedAt,
+  category,
+  likeCount = 0,
+  replyCount = 0,
+  className = "",
+}) {
+  const date = postedAt instanceof Date ? postedAt : new Date(postedAt);
+  const isoTime = isNaN(date.getTime()) ? undefined : date.toISOString();
+  const displayTime = isNaN(date.getTime()) ? String(postedAt) : formatRelativeTime(date);
+
+  return (
+    <dl
+      className={`discussion-metadata ${className}`}
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        alignItems: "center",
+        gap: "0.75rem",
+        fontSize: "0.875rem",
+        color: "#555",
+        margin: 0,
+      }}
+    >
+      {/* Posted time */}
+      <div style={{ display: "flex", alignItems: "center", gap: "0.25rem" }}>
+        <dt className="sr-only" style={visuallyHidden}>
+          Posted
+        </dt>
+        <dd style={{ margin: 0 }}>
+          <time dateTime={isoTime} title={isoTime}>
+            {displayTime}
+          </time>
+        </dd>
+      </div>
+
+      {/* Category */}
+      {category && (
+        <div style={{ display: "flex", alignItems: "center", gap: "0.25rem" }}>
+          <dt className="sr-only" style={visuallyHidden}>
+            Category
+          </dt>
+          <dd style={{ margin: 0 }}>
+            <span
+              className="discussion-metadata__category"
+              style={{
+                padding: "0.125rem 0.5rem",
+                borderRadius: "9999px",
+                background: "#eef1f5",
+                fontWeight: 500,
+              }}
+            >
+              {category}
+            </span>
+          </dd>
+        </div>
+      )}
+
+      {/* Like count */}
+      <div style={{ display: "flex", alignItems: "center", gap: "0.25rem" }}>
+        <dt className="sr-only" style={visuallyHidden}>
+          Likes
+        </dt>
+        <dd style={{ margin: 0 }} aria-label={`${likeCount} likes`}>
+          {formatCount(likeCount)} {likeCount === 1 ? "like" : "likes"}
+        </dd>
+      </div>
+
+      {/* Reply count */}
+      <div style={{ display: "flex", alignItems: "center", gap: "0.25rem" }}>
+        <dt className="sr-only" style={visuallyHidden}>
+          Replies
+        </dt>
+        <dd style={{ margin: 0 }} aria-label={`${replyCount} replies`}>
+          {formatCount(replyCount)} {replyCount === 1 ? "reply" : "replies"}
+        </dd>
+      </div>
+    </dl>
+  );
+}
+
+const visuallyHidden = {
+  position: "absolute",
+  width: "1px",
+  height: "1px",
+  padding: 0,
+  margin: "-1px",
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  border: 0,
+};
+
+/* Example usage:
+
+<DiscussionMetadata
+  postedAt="2026-07-28T10:00:00Z"
+  category="General"
+  likeCount={128}
+  replyCount={34}
+/>
+
+*/


### PR DESCRIPTION
closes #679 



## Extract discussion metadata into reusable component

**Summary**

Extracts the discussion metadata display (posted time, category, likes, replies) into a standalone `DiscussionMetadata` component, replacing the inline markup duplicated across discussion views.

**Changes**
- Added `DiscussionMetadata.jsx` — accepts `postedAt`, `category`, `likeCount`, `replyCount` as props
- Posted time renders via `<time dateTime>` with relative formatting (`2h ago`, `3d ago`, falls back to a formatted date after 7 days)
- Counts formatted compactly for large numbers (`1.2k`)
- Metadata wrapped in `<dl>/<dt>/<dd>` for semantic label/value pairing, with visually-hidden `<dt>` labels + `aria-label`s for screen readers

**Why**
Metadata markup was previously duplicated in-line wherever discussions render, making styling/updates error-prone. This centralizes it into one component with a clear props API.

**Testing**
- [ ] Verified rendering with various `postedAt` values (just now, minutes/hours/days ago, >7 days)
- [ ] Verified singular/plural handling on like/reply counts (1 like vs 128 likes)
- [ ] Checked screen reader output for `<dl>` structure and `aria-label`s
- [ ] Confirmed no layout regressions where component replaces old inline markup

**Follow-ups (optional, not blocking)**
- Swap inline styles for Tailwind classes to match design system
- Consider `Intl.RelativeTimeFormat` for i18n support on the time display

