### PR TITLE
Feat/avatar

### DIFF
--- a/app/CategoryBadge.tsx
+++ b/app/CategoryBadge.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+
+/**
+ * CategoryBadge
+ * A reusable badge component for representing discussion categories,
+ * with colors assigned dynamically based on the category name.
+ *
+ * Usage:
+ *   <CategoryBadge category="Career Growth" />
+ *   <CategoryBadge category="Leadership" />
+ *
+ * If you want to force a specific color instead of the auto-generated one,
+ * pass a `color` prop matching one of the keys in COLOR_MAP (e.g. "teal").
+ */
+
+// Curated set of accessible color combinations (bg + text).
+// Add more entries here if you need a larger palette.
+const COLOR_MAP = {
+  purple: { bg: "#EEEDFE", text: "#3C3489", border: "#AFA9EC" },
+  teal: { bg: "#E1F5EE", text: "#085041", border: "#5DCAA5" },
+  coral: { bg: "#FAECE7", text: "#712B13", border: "#F0997B" },
+  pink: { bg: "#FBEAF0", text: "#72243E", border: "#ED93B1" },
+  blue: { bg: "#E6F1FB", text: "#0C447C", border: "#85B7EB" },
+  green: { bg: "#EAF3DE", text: "#27500A", border: "#97C459" },
+  amber: { bg: "#FAEEDA", text: "#633806", border: "#EF9F27" },
+  gray: { bg: "#F1EFE8", text: "#444441", border: "#B4B2A9" },
+};
+
+const COLOR_KEYS = Object.keys(COLOR_MAP);
+
+// Deterministically map a string to one of the palette colors,
+// so the same category name always gets the same color.
+function hashStringToColorKey(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+    hash |= 0; // convert to 32-bit int
+  }
+  const index = Math.abs(hash) % COLOR_KEYS.length;
+  return COLOR_KEYS[index];
+}
+
+export default function CategoryBadge({ category, color, className = "" }) {
+  const colorKey =
+    color && COLOR_MAP[color] ? color : hashStringToColorKey(category || "");
+  const { bg, text, border } = COLOR_MAP[colorKey];
+
+  return (
+    <span
+      className={className}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        padding: "4px 12px",
+        borderRadius: "999px",
+        fontSize: "13px",
+        fontWeight: 500,
+        backgroundColor: bg,
+        color: text,
+        border: `1px solid ${border}`,
+        whiteSpace: "nowrap",
+        lineHeight: 1.4,
+      }}
+    >
+      {category}
+    </span>
+  );
+}
+
+// --- Demo (remove or replace with your own usage) ---
+export function CategoryBadgeDemo() {
+  const categories = [
+    "Career Growth",
+    "Leadership",
+    "Interview Prep",
+    "Networking",
+  ];
+
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", padding: "16px" }}>
+      {categories.map((cat) => (
+        <CategoryBadge key={cat} category={cat} />
+      ))}
+    </div>
+  );
+}

--- a/components/Avatar1.tsx
+++ b/components/Avatar1.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from "react";
+
+/**
+ * Avatar
+ *
+ * A reusable avatar component for discussion/community authors.
+ *
+ * - Renders a circular profile image when `src` is provided and loads successfully.
+ * - Falls back to the author's initials (on a deterministic color background)
+ *   when `src` is missing, empty, or fails to load.
+ * - Responsive sizing via the `size` prop (accepts a token or a raw number in px).
+ *
+ * Usage:
+ *   <Avatar name="Ada Lovelace" src={author.avatarUrl} size="md" />
+ *   <Avatar name="Grace Hopper" size={56} />
+ */
+
+export type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl" | number;
+
+export interface AvatarProps {
+  /** Full display name, used to derive fallback initials and alt text. */
+  name: string;
+  /** Profile image URL. If omitted/empty/broken, initials are shown instead. */
+  src?: string | null;
+  /** Size token (xs/sm/md/lg/xl) or a custom pixel number. Default: "md". */
+  size?: AvatarSize;
+  /** Optional extra class names for layout/spacing from the parent. */
+  className?: string;
+  /** Optional ring/border color override (defaults to a subtle neutral). */
+  ringColor?: string;
+}
+
+const SIZE_MAP: Record<Exclude<AvatarSize, number>, number> = {
+  xs: 24,
+  sm: 32,
+  md: 40,
+  lg: 56,
+  xl: 80,
+};
+
+// A small, pleasant palette for deterministic initials backgrounds.
+const PALETTE = [
+  "#F97066", // coral
+  "#F79009", // amber
+  "#7A5AF8", // purple
+  "#2E90FA", // blue
+  "#12B76A", // green
+  "#EE46BC", // pink
+  "#06AED4", // teal
+];
+
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+function getColorForName(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const index = Math.abs(hash) % PALETTE.length;
+  return PALETTE[index];
+}
+
+function resolveSize(size: AvatarSize): number {
+  return typeof size === "number" ? size : SIZE_MAP[size] ?? SIZE_MAP.md;
+}
+
+export default function Avatar({
+  name,
+  src,
+  size = "md",
+  className = "",
+  ringColor = "rgba(0, 0, 0, 0.08)",
+}: AvatarProps) {
+  const [imageFailed, setImageFailed] = useState(false);
+
+  const px = resolveSize(size);
+  const hasImage = Boolean(src) && !imageFailed;
+  const initials = getInitials(name);
+  const bgColor = getColorForName(name);
+
+  const baseStyle: React.CSSProperties = {
+    width: px,
+    height: px,
+    minWidth: px,
+    minHeight: px,
+    borderRadius: "50%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+    boxShadow: `0 0 0 1px ${ringColor}`,
+    flexShrink: 0,
+    fontFamily:
+      "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+    userSelect: "none",
+  };
+
+  if (hasImage) {
+    return (
+      <img
+        src={src as string}
+        alt={name}
+        title={name}
+        width={px}
+        height={px}
+        style={{ ...baseStyle, objectFit: "cover" }}
+        className={className}
+        onError={() => setImageFailed(true)}
+        loading="lazy"
+      />
+    );
+  }
+
+  return (
+    <div
+      role="img"
+      aria-label={name}
+      title={name}
+      style={{
+        ...baseStyle,
+        backgroundColor: bgColor,
+        color: "#ffffff",
+        fontWeight: 600,
+        fontSize: Math.max(10, Math.round(px * 0.4)),
+        lineHeight: 1,
+      }}
+      className={className}
+    >
+      {initials}
+    </div>
+  );
+}


### PR DESCRIPTION
closes #678 



## Add `CommunityAuthorAvatar` component

Adds a reusable `Avatar` component (`Avatar.tsx`) for rendering discussion authors across the community/discussion UI.

### What's included
- Circular avatar image with `object-fit: cover` so images never distort
- Automatic fallback to initials (first + last name, or first two letters for single names) when `src` is missing, empty, or fails to load
- Deterministic background color per author, derived from their name, so the same person always gets the same fallback color
- Responsive sizing via a `size` prop — accepts tokens (`xs`/`sm`/`md`/`lg`/`xl`) or a raw pixel number, so it works in dense comment lists and larger profile headers alike
- Accessible: `alt`/`title`/`aria-label` set to the author's name in both image and fallback states

### How it handles missing images
Two cases are covered:
1. `src` is `null`/`undefined`/`""` → renders initials immediately, no failed network request
2. `src` is present but the image errors on load (404, broken CDN link, etc.) → `onError` flips local state and swaps to the initials fallback

### Usage
```tsx
<Avatar name={author.name} src={author.avatarUrl} size="sm" />
```

### Testing notes
- Verified fallback renders correctly with no `src`, empty `src`, and a broken URL
- Checked sizing at `xs` through `xl` and a custom numeric size
- Confirmed initials logic handles single-word names, multi-word names, and edge cases (empty string → `?`)

