### PR TITLE
fix: build reusable discussion creation form with validation

### DIFF
--- a/app/api/discussions/route.ts
+++ b/app/api/discussions/route.ts
@@ -63,9 +63,8 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { title, category, content } = body;
+    const { title, category, content, tags } = body;
 
-    // Validate required fields
     if (!title || !category || !content) {
       return NextResponse.json(
         { message: 'Title, category, and content are required' },
@@ -73,7 +72,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Create new discussion
     const newDiscussion = {
       id: String(discussions.length + 1),
       title,
@@ -89,7 +87,7 @@ export async function POST(request: NextRequest) {
       commentCount: 0,
       viewCount: 0,
       isTrending: false,
-      tags: [],
+      tags: Array.isArray(tags) ? tags : [],
     };
 
     discussions.unshift(newDiscussion);

--- a/components/community/CreateDiscussionForm.tsx
+++ b/components/community/CreateDiscussionForm.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { CATEGORIES } from '@/lib/filters';
 import RichTextEditor from './RichTextEditor';
+import { X, Tag } from 'lucide-react';
 
 const createDiscussionSchema = z.object({
   title: z.string().min(5, 'Title must be at least 5 characters').max(200, 'Title must be less than 200 characters'),
@@ -16,13 +17,16 @@ const createDiscussionSchema = z.object({
 type CreateDiscussionFormData = z.infer<typeof createDiscussionSchema>;
 
 interface Props {
+  onSubmit?: (data: CreateDiscussionFormData & { tags: string[] }) => Promise<void> | void;
   onSuccess?: () => void;
 }
 
-export default function CreateDiscussionForm({ onSuccess }: Props) {
+export default function CreateDiscussionForm({ onSubmit, onSuccess }: Props) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [content, setContent] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState('');
 
   const {
     register,
@@ -33,35 +37,57 @@ export default function CreateDiscussionForm({ onSuccess }: Props) {
   } = useForm<CreateDiscussionFormData>({
     resolver: zodResolver(createDiscussionSchema),
     defaultValues: {
+      title: '',
+      category: '',
       content: '',
     },
   });
 
-  const onSubmit = async (data: CreateDiscussionFormData) => {
+  const handleAddTag = () => {
+    const trimmedTag = tagInput.trim().toLowerCase();
+    if (trimmedTag && !tags.includes(trimmedTag) && tags.length < 5) {
+      setTags([...tags, trimmedTag]);
+      setTagInput('');
+    }
+  };
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    setTags(tags.filter(tag => tag !== tagToRemove));
+  };
+
+  const handleTagInputKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAddTag();
+    }
+  };
+
+  const onFormSubmit = async (data: CreateDiscussionFormData) => {
     setIsSubmitting(true);
     setError(null);
 
     try {
-      const submissionData = {
-        ...data,
-        content,
-      };
+      if (onSubmit) {
+        await onSubmit({ ...data, tags });
+      } else {
+        const response = await fetch('/api/discussions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ ...data, content, tags }),
+        });
 
-      const response = await fetch('/api/discussions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(submissionData),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.message || 'Failed to create discussion');
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.message || 'Failed to create discussion');
+        }
       }
 
       reset();
       setContent('');
+      setTags([]);
+      setTagInput('');
       onSuccess?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unexpected error occurred');
@@ -73,14 +99,14 @@ export default function CreateDiscussionForm({ onSuccess }: Props) {
   return (
     <div className="bg-white rounded-lg shadow p-6">
       <h2 className="text-xl font-semibold text-gray-900 mb-4">Create New Discussion</h2>
-      
+
       {error && (
         <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
           <p className="text-sm text-red-600">{error}</p>
         </div>
       )}
 
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <form onSubmit={handleSubmit(onFormSubmit)} className="space-y-4">
         <div>
           <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-1">
             Title
@@ -122,10 +148,63 @@ export default function CreateDiscussionForm({ onSuccess }: Props) {
           <label htmlFor="content" className="block text-sm font-medium text-gray-700 mb-1">
             Content
           </label>
-          <RichTextEditor content={content} onChange={setContent} />
+          <RichTextEditor
+            content={content}
+            onChange={(newContent) => {
+              setContent(newContent);
+              setValue('content', newContent, { shouldValidate: true });
+            }}
+          />
           {errors.content && (
             <p className="mt-1 text-sm text-red-600">{errors.content.message}</p>
           )}
+        </div>
+
+        <div>
+          <label htmlFor="tag-input" className="block text-sm font-medium text-gray-700 mb-1">
+            Tags <span className="text-gray-400 font-normal">(optional)</span>
+          </label>
+          <div className="flex flex-wrap gap-2 mb-2">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center gap-1 px-3 py-1 bg-cyan-100 text-cyan-700 rounded-full text-sm"
+              >
+                #{tag}
+                <button
+                  type="button"
+                  onClick={() => handleRemoveTag(tag)}
+                  className="hover:text-cyan-900"
+                  aria-label={`Remove tag ${tag}`}
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <div className="relative flex-1">
+              <Tag className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+              <input
+                id="tag-input"
+                type="text"
+                value={tagInput}
+                onChange={(e) => setTagInput(e.target.value)}
+                onKeyDown={handleTagInputKeyDown}
+                className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
+                placeholder="Add a tag (max 5)"
+                disabled={tags.length >= 5}
+              />
+            </div>
+            <button
+              type="button"
+              onClick={handleAddTag}
+              disabled={!tagInput.trim() || tags.length >= 5}
+              className="px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              Add
+            </button>
+          </div>
         </div>
 
         <div className="flex justify-end">


### PR DESCRIPTION
CLOSES #698 
- Add tags field with add/remove UI to CreateDiscussionForm
- Fix content validation by syncing RichTextEditor state with react-hook-form via setValue
- Make form reusable by accepting onSubmit callback instead of hardcoding API call
- Update API route to accept and store tags array