### PR TITLE
fix: resolve Issue 621 - implement functional resource search bar in hero section

### DIFF
--- a/app/(public)/resources/page.tsx
+++ b/app/(public)/resources/page.tsx
@@ -86,6 +86,6 @@ export default function ResourcesPage() {
 
       {/* CTA Section */}
       <CTASection />
-    </div>
+    </main>
   );
 }

--- a/components/ResourceSearchBar.tsx
+++ b/components/ResourceSearchBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React, { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import React, { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Search } from 'lucide-react';
 
 export interface ResourceSearchBarProps {
@@ -13,8 +13,15 @@ export default function ResourceSearchBar({
   onSearch,
   placeholder = 'Search learning tracks, articles, tools, and templates...',
 }: ResourceSearchBarProps) {
-  const [query, setQuery] = useState('');
+  const searchParams = useSearchParams();
+  const [query, setQuery] = useState(() => searchParams.get('q') ?? '');
   const router = useRouter();
+
+  // Keep query in sync if URL param changes externally (e.g. from HeroSearchBar)
+  useEffect(() => {
+    const q = searchParams.get('q');
+    if (q !== null) setQuery(q);
+  }, [searchParams]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -26,7 +33,7 @@ export default function ResourceSearchBar({
 
   return (
     <div className="w-full max-w-3xl mx-auto px-4 py-6">
-      <form onSubmit={handleSubmit} role="search" className="relative">
+      <form onSubmit={handleSubmit} role="search" className="relative" aria-label="Search resources">
         <label htmlFor="resource-search" className="sr-only">
           Search learning resources, guides, and templates
         </label>

--- a/components/resources/HeroSearchBar.tsx
+++ b/components/resources/HeroSearchBar.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { SearchIcon } from '@/components/resources/icons';
+
+/**
+ * HeroSearchBar — Functional search input styled for the hero section.
+ *
+ * Replaces the previously decorative-only search prompt CTA in the
+ * Resources HeroSection with a real, interactive search input.
+ *
+ * On submit, navigates to /resources?q=<query> so the page-level
+ * ResourceSearchBar can pick up the query.
+ */
+export default function HeroSearchBar() {
+  const [query, setQuery] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    router.push(`/resources?q=${encodeURIComponent(trimmed)}`);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} role="search" className="w-full max-w-md sm:w-auto sm:min-w-[320px]" aria-label="Quick resource search">
+      <label htmlFor="hero-resource-search" className="sr-only">
+        Search guides, tutorials, and tools
+      </label>
+      <div className="relative flex items-center">
+        <div className="absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none">
+          <SearchIcon className="h-4 w-4 shrink-0 text-purple-300" />
+        </div>
+        <input
+          id="hero-resource-search"
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search guides, tutorials, tools…"
+          className="w-full rounded-full border border-white/20 bg-white/10 py-3 pl-10 pr-4 text-sm text-white placeholder-purple-200/60 backdrop-blur-sm outline-none transition hover:border-white/30 focus:border-white/40 focus:bg-white/15 focus:ring-2 focus:ring-white/20"
+        />
+      </div>
+    </form>
+  );
+}

--- a/components/resources/HeroSection.tsx
+++ b/components/resources/HeroSection.tsx
@@ -1,4 +1,4 @@
-import { SearchIcon } from "@/components/resources/icons";
+import HeroSearchBar from '@/components/resources/HeroSearchBar';
 
 /**
  * HeroSection — Resources page gradient hero.
@@ -67,18 +67,13 @@ export default function HeroSection() {
             at every stage.
           </p>
 
-          {/* Search prompt CTA */}
+          {/* Search + Browse CTA */}
           <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-            <div className="flex w-full max-w-md items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-3 text-sm text-purple-200 backdrop-blur-sm sm:w-auto sm:min-w-[320px]">
-              <SearchIcon className="h-4 w-4 shrink-0 text-purple-300" />
-              <span className="text-purple-200/80">
-                Search guides, tutorials, tools…
-              </span>
-            </div>
+            <HeroSearchBar />
             <a
               href="#categories"
               aria-label="Browse resource topics"
-              className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-purple-700 shadow-sm transition hover:bg-purple-50 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-purple-700"
+              className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-purple-700 shadow-sm transition hover:bg-purple-50 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-purple-700 shrink-0"
             >
               Browse topics
               <svg

--- a/issue621.md
+++ b/issue621.md
@@ -1,6 +1,8 @@
 Title
 Implement Resource Search Bar
 
+Status: ✅ RESOLVED
+
 Description
 Add search input below hero section.
 
@@ -13,4 +15,11 @@ Controlled input state
 Acceptance Criteria
 Clean styling
 Input state functional
+
+Resolution
+- Created HeroSearchBar client component (components/resources/HeroSearchBar.tsx) with a real functional search input styled for the hero gradient
+- Replaced the decorative-only search prompt in HeroSection with the new HeroSearchBar
+- Updated ResourceSearchBar to read URL search params so it stays in sync with hero searches
+- Fixed </div> → </main> tag mismatch in resources/page.tsx
+- Added aria-labels to distinguish the two search landmarks
 


### PR DESCRIPTION
## Summary

Resolves Issue #621 by making the hero section search bar functional instead of decorative-only.

## Changes

- **New:** `components/resources/HeroSearchBar.tsx` — Functional search input client component styled for the hero gradient
- **Modified:** `components/resources/HeroSection.tsx` — Replaced decorative search prompt with `<HeroSearchBar />`
- **Modified:** `components/ResourceSearchBar.tsx` — Now reads URL search params so it stays in sync when search originates from hero bar
- **Fixed:** `app/(public)/resources/page.tsx` — Corrected `</div>` → `</main>` tag mismatch
- **Updated:** `issue621.md` — Marked as resolved with notes

## How to test

1. Visit `/resources`
2. Type a search query in the hero section search bar (top of page, purple gradient)
3. Press Enter — you should navigate to `/resources?q=yourquery`
4. The search bar below the hero should show your query

Closes #717 
Closes #718 
Closes #719 